### PR TITLE
Introduce MData enum and add more RPCs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ pub type XorName = [u8; XOR_NAME_LEN];
 /// routes, the same message will usually arrive more than once at any given node. A message with
 /// an ID that is already in the cache will be ignored.
 #[derive(Ord, PartialOrd, Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash)]
-pub struct MessageId(XorName);
+pub struct MessageId(pub XorName);
 
 // Impl this in SAFE Client Libs if we still need old routing Message IDs:
 //

--- a/src/request.rs
+++ b/src/request.rs
@@ -49,7 +49,14 @@ pub enum Request {
     GetUnpubIData(XorName),
     PutUnpubIData(UnpubImmutableData),
     DeleteUnpubIData(XorName),
-
+    DeleteMData {
+        // Address of the mutable data to be fetched
+        address: MutableDataRef,
+        // Requester public key
+        requester: threshold_crypto::PublicKey,
+        // Unique message Identifier
+        message_id: MessageId,
+    },
     GetUnseqMData {
         // Address of the mutable data to be fetched
         address: MutableDataRef,
@@ -125,7 +132,6 @@ pub enum Request {
         requester: threshold_crypto::PublicKey,
         message_id: MessageId,
     },
-}
 
     // ===== Append Only Data =====
     // Get a range of entries from an AppendOnlyData object on the network.
@@ -285,6 +291,7 @@ impl fmt::Debug for Request {
             Request::ListMDataKeys { .. } => "Request::ListMDataKeys",
             Request::ListUnseqMDataValues { .. } => "Request::ListUnseqMDataValues",
             Request::ListSeqMDataValues { .. } => "Request::ListSeqMDataValues",
+            Request::DeleteMData { .. } => "Request::DeleteMData",
             // TODO
             ref _x => "Request",
         };

--- a/src/request.rs
+++ b/src/request.rs
@@ -78,6 +78,55 @@ pub enum Request {
         message_id: MessageId,
     },
 
+    GetSeqMDataShell {
+        address: MutableDataRef,
+        requester: threshold_crypto::PublicKey,
+        message_id: MessageId,
+    },
+
+    GetUnseqMDataShell {
+        address: MutableDataRef,
+        requester: threshold_crypto::PublicKey,
+        message_id: MessageId,
+    },
+
+    GetMDataVersion {
+        address: MutableDataRef,
+        requester: threshold_crypto::PublicKey,
+        message_id: MessageId,
+    },
+
+    ListUnseqMDataEntries {
+        address: MutableDataRef,
+        requester: threshold_crypto::PublicKey,
+        message_id: MessageId,
+    },
+
+    ListSeqMDataEntries {
+        address: MutableDataRef,
+        requester: threshold_crypto::PublicKey,
+        message_id: MessageId,
+    },
+
+    ListMDataKeys {
+        address: MutableDataRef,
+        requester: threshold_crypto::PublicKey,
+        message_id: MessageId,
+    },
+
+    ListUnseqMDataValues {
+        address: MutableDataRef,
+        requester: threshold_crypto::PublicKey,
+        message_id: MessageId,
+    },
+
+    ListSeqMDataValues {
+        address: MutableDataRef,
+        requester: threshold_crypto::PublicKey,
+        message_id: MessageId,
+    },
+}
+
     // ===== Append Only Data =====
     // Get a range of entries from an AppendOnlyData object on the network.
     GetADataRange {
@@ -228,6 +277,14 @@ impl fmt::Debug for Request {
             Request::PutUnseqMData { .. } => "Request::PutUnseqMData",
             Request::GetSeqMData { .. } => "Request::GetSeqMData",
             Request::PutSeqMData { .. } => "Request::PutSeqMData",
+            Request::GetSeqMDataShell { .. } => "Request::GetSeqMDataShell",
+            Request::GetUnseqMDataShell { .. } => "Request::GetUnseqMDataShell",
+            Request::GetMDataVersion { .. } => "Request::GetMDataVersion",
+            Request::ListUnseqMDataEntries { .. } => "Request::ListUnseqMDataEntries",
+            Request::ListSeqMDataEntries { .. } => "Request::ListSeqMDataEntries",
+            Request::ListMDataKeys { .. } => "Request::ListMDataKeys",
+            Request::ListUnseqMDataValues { .. } => "Request::ListUnseqMDataValues",
+            Request::ListSeqMDataValues { .. } => "Request::ListSeqMDataValues",
             // TODO
             ref _x => "Request",
         };

--- a/src/request.rs
+++ b/src/request.rs
@@ -53,7 +53,7 @@ pub enum Request {
         // Address of the mutable data to be fetched
         address: MutableDataRef,
         // Requester public key
-        requester: threshold_crypto::PublicKey,
+        requester: Requester,
         // Unique message Identifier
         message_id: MessageId,
     },
@@ -87,49 +87,49 @@ pub enum Request {
 
     GetSeqMDataShell {
         address: MutableDataRef,
-        requester: threshold_crypto::PublicKey,
+        requester: Requester,
         message_id: MessageId,
     },
 
     GetUnseqMDataShell {
         address: MutableDataRef,
-        requester: threshold_crypto::PublicKey,
+        requester: Requester,
         message_id: MessageId,
     },
 
     GetMDataVersion {
         address: MutableDataRef,
-        requester: threshold_crypto::PublicKey,
+        requester: Requester,
         message_id: MessageId,
     },
 
     ListUnseqMDataEntries {
         address: MutableDataRef,
-        requester: threshold_crypto::PublicKey,
+        requester: Requester,
         message_id: MessageId,
     },
 
     ListSeqMDataEntries {
         address: MutableDataRef,
-        requester: threshold_crypto::PublicKey,
+        requester: Requester,
         message_id: MessageId,
     },
 
     ListMDataKeys {
         address: MutableDataRef,
-        requester: threshold_crypto::PublicKey,
+        requester: Requester,
         message_id: MessageId,
     },
 
     ListUnseqMDataValues {
         address: MutableDataRef,
-        requester: threshold_crypto::PublicKey,
+        requester: Requester,
         message_id: MessageId,
     },
 
     ListSeqMDataValues {
         address: MutableDataRef,
-        requester: threshold_crypto::PublicKey,
+        requester: Requester,
         message_id: MessageId,
     },
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -8,9 +8,10 @@
 // Software.
 
 use crate::immutable_data::UnpubImmutableData;
-use crate::mutable_data::{SeqMutableData, UnseqMutableData};
+use crate::mutable_data::{SeqMutableData, UnseqMutableData, Value};
 use crate::MessageId;
 use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
 
 /// RPC responses from vaults.
 #[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
@@ -35,6 +36,38 @@ pub enum Response<ErrorType> {
         res: Result<(), ErrorType>,
         msg_id: MessageId,
     },
+    GetSeqMDataShell {
+        res: Result<SeqMutableData, ErrorType>,
+        msg_id: MessageId,
+    },
+    GetUnseqMDataShell {
+        res: Result<UnseqMutableData, ErrorType>,
+        msg_id: MessageId,
+    },
+    GetMDataVersion {
+        res: Result<u64, ErrorType>,
+        msg_id: MessageId,
+    },
+    ListUnseqMDataEntries {
+        res: Result<BTreeMap<Vec<u8>, Vec<u8>>, ErrorType>,
+        msg_id: MessageId,
+    },
+    ListSeqMDataEntries {
+        res: Result<BTreeMap<Vec<u8>, Value>, ErrorType>,
+        msg_id: MessageId,
+    },
+    ListMDataKeys {
+        res: Result<BTreeSet<Vec<u8>>, ErrorType>,
+        msg_id: MessageId,
+    },
+    ListSeqMDataValues {
+        res: Result<Vec<Value>, ErrorType>,
+        msg_id: MessageId,
+    },
+    ListUnseqMDataValues {
+        res: Result<Vec<Vec<u8>>, ErrorType>,
+        msg_id: MessageId,
+    },
 }
 
 use std::fmt;
@@ -49,6 +82,14 @@ impl<T> fmt::Debug for Response<T> {
             Response::PutUnseqMData { .. } => "Response::PutUnseqMData",
             Response::GetSeqMData { .. } => "Response::GetSeqMData",
             Response::PutSeqMData { .. } => "Response::PutSeqMData",
+            Response::GetSeqMDataShell { .. } => "Response::GetMDataShell",
+            Response::GetUnSeqMDataShell { .. } => "Response::GetMDataShell",
+            Response::GetMDataVersion { .. } => "Response::GetMDataVersion",
+            Response::ListUnseqMDataEntries { .. } => "Response::ListUnseqMDataEntries",
+            Response::ListSeqMDataEntries { .. } => "Response::ListSeqMDataEntries",
+            Response::ListMDataKeys { .. } => "Response::ListMDataKeys",
+            Response::ListSeqMDataValues { .. } => "Response::ListSeqMDataValues",
+            Response::ListUnseqMDataValues { .. } => "Response::ListUnseqMDataValues",
         };
         write!(f, "{}", printable)
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -19,7 +19,6 @@ pub enum Response<ErrorType> {
     GetUnpubIData(Result<UnpubImmutableData, ErrorType>),
     PutUnpubIData(Result<(), ErrorType>),
     DeleteUnpubIData(Result<(), ErrorType>),
-
     GetUnseqMData {
         res: Result<UnseqMutableData, ErrorType>,
         msg_id: MessageId,
@@ -68,6 +67,10 @@ pub enum Response<ErrorType> {
         res: Result<Vec<Vec<u8>>, ErrorType>,
         msg_id: MessageId,
     },
+    DeleteMData {
+        res: Result<(), ErrorType>,
+        msg_id: MessageId,
+    },
 }
 
 use std::fmt;
@@ -78,12 +81,13 @@ impl<T> fmt::Debug for Response<T> {
             Response::GetUnpubIData { .. } => "Response::GetUnpubIData",
             Response::PutUnpubIData { .. } => "Response::PutUnpubIData",
             Response::DeleteUnpubIData { .. } => "Response::DeleteUnpubIData",
+            Response::DeleteMData { .. } => "Response::DeleteMData",
             Response::GetUnseqMData { .. } => "Response::GetUnseqMData",
             Response::PutUnseqMData { .. } => "Response::PutUnseqMData",
             Response::GetSeqMData { .. } => "Response::GetSeqMData",
             Response::PutSeqMData { .. } => "Response::PutSeqMData",
             Response::GetSeqMDataShell { .. } => "Response::GetMDataShell",
-            Response::GetUnSeqMDataShell { .. } => "Response::GetMDataShell",
+            Response::GetUnseqMDataShell { .. } => "Response::GetMDataShell",
             Response::GetMDataVersion { .. } => "Response::GetMDataVersion",
             Response::ListUnseqMDataEntries { .. } => "Response::ListUnseqMDataEntries",
             Response::ListSeqMDataEntries { .. } => "Response::ListSeqMDataEntries",


### PR DESCRIPTION
- Introduce MutableData enum to group sequenced and unsequenced types
- Add variants to Request and Reseponse to handle more RPCs for MData
operations