### PR TITLE
Get rid of routing and maidsafe_utils dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,14 @@ authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 edition = "2018"
 
 [dependencies]
-maidsafe_utilities = "~0.18.0"
-routing = { git = "https://github.com/lionel1704/routing", branch = "patch" }
 rust_sodium = "~0.10.2"
 serde = { version = "~1.0.92", features = ["derive"] }
 threshold_crypto = "~0.3.1"
 tiny-keccak = "~1.4.2"
+bincode = "~1.1.4"
+unwrap = "~1.2.1"
 
 [dev-dependencies]
 hex = "~0.3.2"
-rand = "~0.4.2"
-unwrap = "~1.2.1"
+rand = "~0.6.5"
+rand_xorshift = "~0.1.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,6 @@ pub mod request;
 pub mod response;
 
 pub use immutable_data::{ImmutableData, UnpubImmutableData, MAX_IMMUTABLE_DATA_SIZE_IN_BYTES};
-use routing::MessageId as OldMessageId;
 use serde::{Deserialize, Serialize};
 
 /// Constant byte length of `XorName`.
@@ -101,16 +100,17 @@ pub type XorName = [u8; XOR_NAME_LEN];
 #[derive(Ord, PartialOrd, Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct MessageId(XorName);
 
-impl From<OldMessageId> for MessageId {
-    fn from(old_msg_id: OldMessageId) -> Self {
-        MessageId {
-            0: (old_msg_id.0).0,
-        }
-    }
-}
-
-impl Into<OldMessageId> for MessageId {
-    fn into(self) -> OldMessageId {
-        OldMessageId::from_name_array(self.0)
-    }
-}
+// Impl this in SAFE Client Libs if we still need old routing Message IDs:
+//
+// impl From<OldMessageId> for MessageId {
+//     fn from(old_msg_id: OldMessageId) -> Self {
+//         MessageId {
+//             0: (old_msg_id.0).0,
+//         }
+//     }
+// }
+// impl Into<OldMessageId> for MessageId {
+//     fn into(self) -> OldMessageId {
+//         OldMessageId::from_name_array(self.0)
+//     }
+// }

--- a/src/response.rs
+++ b/src/response.rs
@@ -10,7 +10,6 @@
 use crate::immutable_data::UnpubImmutableData;
 use crate::mutable_data::{SeqMutableData, UnseqMutableData};
 use crate::MessageId;
-use routing::ClientError;
 use serde::{Deserialize, Serialize};
 
 /// RPC responses from vaults.
@@ -40,7 +39,7 @@ pub enum Response<ErrorType> {
 
 use std::fmt;
 
-impl fmt::Debug for Response<ClientError> {
+impl<T> fmt::Debug for Response<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let printable = match *self {
             Response::GetUnpubIData { .. } => "Response::GetUnpubIData",


### PR DESCRIPTION
Define required types inline and use bincode for serialisation.