### PR TITLE
Implement the basic functions of AppendOnlyData

### DIFF
--- a/src/appendable_data.rs
+++ b/src/appendable_data.rs
@@ -49,7 +49,8 @@ pub struct UnpubPermissionSet {
 }
 
 impl UnpubPermissionSet {
-    fn is_allowed(&self, action: Action) -> bool {
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    pub fn is_allowed(&self, action: Action) -> bool {
         match action {
             Action::Read => self.read,
             Action::Append => self.append,
@@ -65,7 +66,8 @@ pub struct PubPermissionSet {
 }
 
 impl PubPermissionSet {
-    fn is_allowed(&self, action: Action) -> Option<bool> {
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    pub fn is_allowed(&self, action: Action) -> Option<bool> {
         match action {
             Action::Read => Some(true), // It's published data, so it's always allowed to read it.
             Action::Append => self.append,

--- a/src/appendable_data.rs
+++ b/src/appendable_data.rs
@@ -1,0 +1,542 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::errors::Error;
+use crate::request::{Request, Requester};
+use crate::XorName;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use threshold_crypto::{PublicKey, PublicKeySet};
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum User {
+    Anyone,
+    Key(PublicKey),
+}
+
+pub fn check_permissions<P: Permissions>(
+    _data: impl AppendOnlyData<P>,
+    _rpc: &Request,
+    _requester: Requester,
+) -> Result<bool, Error> {
+    // TODO
+    Ok(true)
+}
+
+#[derive(Clone, Copy)]
+pub enum Action {
+    Read,
+    Append,
+    ManagePermissions,
+}
+
+#[derive(Copy, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum Index {
+    FromStart(u64), // Absolute index
+    FromEnd(u64),   // Relative index - start counting from the end
+}
+
+#[derive(Copy, Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash)]
+pub struct UnpubPermissionSet {
+    read: bool,
+    append: bool,
+    manage_permissions: bool,
+}
+
+impl UnpubPermissionSet {
+    fn is_allowed(&self, action: Action) -> bool {
+        match action {
+            Action::Read => self.read,
+            Action::Append => self.append,
+            Action::ManagePermissions => self.manage_permissions,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash)]
+pub struct PubPermissionSet {
+    append: Option<bool>,
+    manage_permissions: Option<bool>,
+}
+
+impl PubPermissionSet {
+    fn is_allowed(&self, action: Action) -> Option<bool> {
+        match action {
+            Action::Read => Some(true), // It's published data, so it's always allowed to read it.
+            Action::Append => self.append,
+            Action::ManagePermissions => self.manage_permissions,
+        }
+    }
+}
+
+#[derive(Copy, Debug, Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
+pub struct AppendOnlyDataRef {
+    // Address of an AppendOnlyData object on the network.
+    name: XorName,
+    // Type tag.
+    tag: u64,
+}
+
+#[derive(Copy, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum AppendOnlyKind {
+    /// Published, sequenced append-only data
+    PubSeq,
+    /// Published, unsequenced append-only data
+    PubUnseq,
+    /// Unpublished, sequenced append-only data
+    UnpubSeq,
+    /// Unpublished, unsequenced append-only data
+    UnpubUnseq,
+}
+
+pub trait Permissions {
+    fn is_action_allowed(&self, requester: PublicKey, action: Action) -> bool;
+    fn data_index(&self) -> u64;
+    fn owner_entry_index(&self) -> u64;
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash)]
+pub struct UnpubPermissions {
+    permissions: BTreeMap<PublicKey, UnpubPermissionSet>,
+    /// The current index of the data when this permission change happened
+    data_index: u64,
+    /// The current index of the owners when this permission change happened
+    owner_entry_index: u64,
+}
+
+impl Permissions for UnpubPermissions {
+    fn is_action_allowed(&self, requester: PublicKey, action: Action) -> bool {
+        match self.permissions.get(&requester) {
+            Some(perms) => perms.is_allowed(action),
+            None => false,
+        }
+    }
+
+    fn data_index(&self) -> u64 {
+        self.data_index
+    }
+
+    fn owner_entry_index(&self) -> u64 {
+        self.owner_entry_index
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash)]
+pub struct PubPermissions {
+    permissions: BTreeMap<User, PubPermissionSet>,
+    /// The current index of the data when this permission change happened
+    data_index: u64,
+    /// The current index of the owners when this permission change happened
+    owner_entry_index: u64,
+}
+
+impl PubPermissions {
+    fn check_anyone_permissions(&self, action: Action) -> bool {
+        match self.permissions.get(&User::Anyone) {
+            None => false,
+            Some(perms) => perms.is_allowed(action).unwrap_or(false),
+        }
+    }
+}
+
+impl Permissions for PubPermissions {
+    fn is_action_allowed(&self, requester: PublicKey, action: Action) -> bool {
+        match self.permissions.get(&User::Key(requester)) {
+            Some(perms) => perms
+                .is_allowed(action)
+                .unwrap_or_else(|| self.check_anyone_permissions(action)),
+            None => self.check_anyone_permissions(action),
+        }
+    }
+
+    fn data_index(&self) -> u64 {
+        self.data_index
+    }
+
+    fn owner_entry_index(&self) -> u64 {
+        self.owner_entry_index
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct Owners {
+    owners: PublicKeySet,
+    /// The current index of the data when this ownership change happened
+    data_index: u64,
+    /// The current index of the permissions when this ownership change happened
+    permission_entry_index: u64,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash)]
+struct AppendOnly<P: Permissions> {
+    name: XorName,
+    tag: u64,
+    data: Vec<(Vec<u8>, Vec<u8>)>,
+    permissions: Vec<P>,
+    owners: Vec<Owners>,
+}
+
+/// Common methods for all `AppendOnlyData` flavours.
+pub trait AppendOnlyData<P> {
+    // /// Get a list of permissions for the provided user from the last entry in the permissions list.
+    // fn user_permissions(&self, user: &User) -> Result<&PubPermissionSet, ClientError>;
+
+    /// Return a value for the given key (if it is present).
+    fn get(&self, key: &[u8]) -> Option<&Vec<u8>>;
+
+    /// Get a list of keys and values with the given indexes.
+    fn at(&self, start: Index, end: Index) -> Option<&[(Vec<u8>, Vec<u8>)]>;
+
+    /// Return all entries.
+    fn entries(&self) -> &Vec<(Vec<u8>, Vec<u8>)>;
+
+    /// Return the name of this AppendOnlyData.
+    fn name(&self) -> XorName;
+
+    /// Return the type tag of this AppendOnlyData.
+    fn tag(&self) -> u64;
+
+    /// Return the last entry index.
+    fn entry_index(&self) -> u64;
+
+    /// Return the last owners index.
+    fn owners_index(&self) -> u64;
+
+    /// Return the last permissions index.
+    fn permissions_index(&self) -> u64;
+
+    /// Get a complete list of permissions from the entry in the permissions list at the specified index.
+    fn permissions(&self, start: Index, end: Index) -> Option<&[P]>;
+
+    /// Add a new permissions entry.
+    /// The `Permissions` struct should contain valid indexes.
+    fn append_permissions(&mut self, permissions: P) -> Result<(), Error>;
+
+    /// Get a complete list of owners from the entry in the permissions list at the specified index.
+    fn owners(&self, start: Index, end: Index) -> Option<&[Owners]>;
+
+    /// Add a new permissions entry.
+    /// The `Owners` struct should contain valid indexes.
+    fn append_owners(&mut self, owners: Owners) -> Result<(), Error>;
+}
+
+/// Common methods for published and unpublished unsequenced `AppendOnlyData`.
+pub trait UnseqAppendOnly {
+    /// Append new entries.
+    fn append(&mut self, entries: &[(Vec<u8>, Vec<u8>)]) -> Result<(), Error>;
+}
+
+/// Common methods for published and unpublished sequenced `AppendOnlyData`.
+pub trait SeqAppendOnly {
+    /// Append new entries.
+    /// If the specified `last_entries_index` does not match the last recorded entries index, an error will be returned.
+    fn append(
+        &mut self,
+        entries: &[(Vec<u8>, Vec<u8>)],
+        last_entries_index: u64,
+    ) -> Result<(), Error>;
+}
+
+macro_rules! impl_appendable_data {
+    ($flavour:ident) => {
+        #[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash)]
+        pub struct $flavour<P>
+        where
+            P: Permissions + std::hash::Hash,
+        {
+            inner: AppendOnly<P>,
+        }
+
+        impl<P> $flavour<P>
+        where
+            P: Permissions + std::hash::Hash,
+        {
+            pub fn new(name: XorName, tag: u64) -> Self {
+                Self {
+                    inner: AppendOnly {
+                        name,
+                        tag,
+                        data: Vec::new(),
+                        permissions: Vec::new(),
+                        owners: Vec::new(),
+                    },
+                }
+            }
+        }
+
+        impl<P> AppendOnlyData<P> for $flavour<P>
+        where
+            P: Permissions + std::hash::Hash,
+        {
+            fn name(&self) -> XorName {
+                self.inner.name
+            }
+
+            fn tag(&self) -> u64 {
+                self.inner.tag
+            }
+
+            fn entry_index(&self) -> u64 {
+                self.inner.data.len() as u64
+            }
+
+            fn owners_index(&self) -> u64 {
+                self.inner.owners.len() as u64
+            }
+
+            fn permissions_index(&self) -> u64 {
+                self.inner.permissions.len() as u64
+            }
+
+            // fn user_permissions(&self, user: &User) -> Result<&PubPermissionSet, Error> {
+            //     let perm_set = &self.inner.permissions[self.inner.permissions.len() - 1];
+            //     perm_set.permissions.get(user).ok_or(Error::X)
+            // }
+
+            fn get(&self, key: &[u8]) -> Option<&Vec<u8>> {
+                self.inner
+                    .data
+                    .iter()
+                    .find_map(|(k, v)| if k.as_slice() == key { Some(v) } else { None })
+            }
+
+            fn at(&self, start: Index, end: Index) -> Option<&[(Vec<u8>, Vec<u8>)]> {
+                let idx_start = match start {
+                    Index::FromStart(idx) => idx as usize,
+                    Index::FromEnd(idx) => self.inner.data.len() - (idx as usize),
+                };
+                let idx_end = match end {
+                    Index::FromStart(idx) => idx as usize,
+                    Index::FromEnd(idx) => self.inner.data.len() - (idx as usize),
+                };
+
+                // Check bounds
+                if idx_start > self.inner.data.len() {
+                    return None;
+                }
+                if idx_end < idx_start {
+                    return None;
+                }
+                if idx_start == idx_end {
+                    // Return empty slice because range len is 0
+                    return Some(&[]);
+                }
+
+                Some(&self.inner.data[idx_start..idx_end])
+            }
+
+            fn entries(&self) -> &Vec<(Vec<u8>, Vec<u8>)> {
+                &self.inner.data
+            }
+
+            fn permissions(&self, start: Index, end: Index) -> Option<&[P]> {
+                // Check bounds
+                let idx_start = match start {
+                    Index::FromStart(idx) => idx as usize,
+                    Index::FromEnd(idx) => self.inner.permissions.len() - (idx as usize),
+                };
+                let idx_end = match end {
+                    Index::FromStart(idx) => idx as usize,
+                    Index::FromEnd(idx) => self.inner.permissions.len() - (idx as usize),
+                };
+                if idx_start > self.inner.permissions.len() {
+                    return None;
+                }
+                if idx_end < idx_start {
+                    return None;
+                }
+                if idx_start == idx_end {
+                    // Empty slice
+                    return Some(&[]);
+                }
+
+                Some(&self.inner.permissions[idx_start..idx_end])
+            }
+
+            fn owners(&self, start: Index, end: Index) -> Option<&[Owners]> {
+                // Check bounds
+                let idx_start = match start {
+                    Index::FromStart(idx) => idx as usize,
+                    Index::FromEnd(idx) => self.inner.owners.len() - (idx as usize),
+                };
+                let idx_end = match end {
+                    Index::FromStart(idx) => idx as usize,
+                    Index::FromEnd(idx) => self.inner.owners.len() - (idx as usize),
+                };
+                if idx_start > self.inner.owners.len() {
+                    return None;
+                }
+                if idx_end < idx_start {
+                    return None;
+                }
+                if idx_start == idx_end {
+                    // Empty slice
+                    return Some(&[]);
+                }
+
+                Some(&self.inner.owners[idx_start..idx_end])
+            }
+
+            fn append_permissions(&mut self, permissions: P) -> Result<(), Error> {
+                if permissions.data_index() != self.entry_index() {
+                    return Err(Error::InvalidSuccessor(self.entry_index()));
+                }
+                if permissions.owner_entry_index() != self.owners_index() {
+                    return Err(Error::InvalidOwnersSuccessor(self.owners_index()));
+                }
+                self.inner.permissions.push(permissions);
+                Ok(())
+            }
+
+            fn append_owners(&mut self, owners: Owners) -> Result<(), Error> {
+                if owners.data_index != self.entry_index() {
+                    return Err(Error::InvalidSuccessor(self.entry_index()));
+                }
+                if owners.permission_entry_index != self.permissions_index() {
+                    return Err(Error::InvalidPermissionsSuccessor(self.permissions_index()));
+                }
+                self.inner.owners.push(owners);
+                Ok(())
+            }
+        }
+    };
+}
+
+impl_appendable_data!(SeqAppendOnlyData);
+impl_appendable_data!(UnseqAppendOnlyData);
+
+impl<P> SeqAppendOnly for SeqAppendOnlyData<P>
+where
+    P: Permissions + std::hash::Hash,
+{
+    fn append(
+        &mut self,
+        entries: &[(Vec<u8>, Vec<u8>)],
+        last_entries_index: u64,
+    ) -> Result<(), Error> {
+        if last_entries_index != self.inner.data.len() as u64 {
+            return Err(Error::InvalidSuccessor(self.inner.data.len() as u64));
+        }
+        self.inner.data.extend(entries.iter().cloned());
+        Ok(())
+    }
+}
+
+impl<P> UnseqAppendOnly for UnseqAppendOnlyData<P>
+where
+    P: Permissions + std::hash::Hash,
+{
+    fn append(&mut self, entries: &[(Vec<u8>, Vec<u8>)]) -> Result<(), Error> {
+        self.inner.data.extend(entries.iter().cloned());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand;
+    use threshold_crypto::SecretKeySet;
+    use unwrap::unwrap;
+
+    #[test]
+    fn append_permissions() {
+        let mut data = SeqAppendOnlyData::<UnpubPermissions>::new([1; 32], 10000);
+
+        // Append the first permission set with correct indexes - should pass.
+        let res = data.append_permissions(UnpubPermissions {
+            permissions: BTreeMap::new(),
+            data_index: 0,
+            owner_entry_index: 0,
+        });
+
+        match res {
+            Ok(()) => (),
+            Err(x) => panic!("Unexpected error: {:?}", x),
+        }
+
+        // Verify that the permissions have been added.
+        assert_eq!(
+            unwrap!(data.permissions(Index::FromStart(0), Index::FromEnd(0),)).len(),
+            1
+        );
+
+        // Append another permissions entry with incorrect indexes - should fail.
+        let res = data.append_permissions(UnpubPermissions {
+            permissions: BTreeMap::new(),
+            data_index: 64,
+            owner_entry_index: 0,
+        });
+
+        match res {
+            Err(_) => (),
+            Ok(()) => panic!("Unexpected Ok(()) result"),
+        }
+
+        // Verify that the number of permissions has not been changed.
+        assert_eq!(
+            unwrap!(data.permissions(Index::FromStart(0), Index::FromEnd(0),)).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn append_owners() {
+        let mut rng = rand::thread_rng();
+        let owners_pk_set = SecretKeySet::random(1, &mut rng);
+
+        let mut data = SeqAppendOnlyData::<UnpubPermissions>::new([1; 32], 10000);
+
+        // Append the first owner with correct indexes - should pass.
+        let res = data.append_owners(Owners {
+            owners: owners_pk_set.public_keys(),
+            data_index: 0,
+            permission_entry_index: 0,
+        });
+
+        match res {
+            Ok(()) => (),
+            Err(x) => panic!("Unexpected error: {:?}", x),
+        }
+
+        // Verify that the owner has been added.
+        assert_eq!(
+            unwrap!(data.owners(Index::FromStart(0), Index::FromEnd(0),)).len(),
+            1
+        );
+
+        // Append another owners entry with incorrect indexes - should fail.
+        let res = data.append_owners(Owners {
+            owners: owners_pk_set.public_keys(),
+            data_index: 64,
+            permission_entry_index: 0,
+        });
+
+        match res {
+            Err(_) => (),
+            Ok(()) => panic!("Unexpected Ok(()) result"),
+        }
+
+        // Verify that the number of owners has not been changed.
+        assert_eq!(
+            unwrap!(data.owners(Index::FromStart(0), Index::FromEnd(0),)).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn seq_append_entries() {
+        let mut data = SeqAppendOnlyData::<PubPermissions>::new([1; 32], 10000);
+        let res = data.append(&[(b"hello".to_vec(), b"world".to_vec())], 0);
+
+        match res {
+            Ok(()) => (),
+            Err(x) => panic!("Unexpected error: {:?}", x),
+        }
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,7 +9,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use std::error::Error as StdError;
+use std::error;
 use std::fmt::{self, Display, Formatter};
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
@@ -88,7 +88,7 @@ impl Display for Error {
     }
 }
 
-impl StdError for Error {
+impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
             Error::AccessDenied => "Access denied",

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,11 +9,11 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use std::error::Error;
+use std::error::Error as StdError;
 use std::fmt::{self, Display, Formatter};
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
-pub enum DataError {
+pub enum Error {
     /// Access is denied for a given requester
     AccessDenied,
     /// /// SAFE Account does not exist for client
@@ -37,6 +37,12 @@ pub enum DataError {
     /// Invalid version for performing a given mutating operation. Contains the
     /// current data version.
     InvalidSuccessor(u64),
+    /// Invalid version for performing a given mutating operation. Contains the
+    /// current owners version.
+    InvalidOwnersSuccessor(u64),
+    /// Invalid version for performing a given mutating operation. Contains the
+    /// current permissions version.
+    InvalidPermissionsSuccessor(u64),
     /// Invalid Operation such as a POST on ImmutableData
     InvalidOperation,
     /// Network error occurring at Vault level which has no bearing on clients, e.g. serialisation
@@ -44,52 +50,62 @@ pub enum DataError {
     NetworkOther(String),
 }
 
-impl<T: Into<String>> From<T> for DataError {
+impl<T: Into<String>> From<T> for Error {
     fn from(err: T) -> Self {
-        DataError::NetworkOther(err.into())
+        Error::NetworkOther(err.into())
     }
 }
 
-impl Display for DataError {
+impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match *self {
-            DataError::AccessDenied => write!(f, "Access denied"),
-            DataError::NoSuchAccount => write!(f, "Account does not exist for client"),
-            DataError::AccountExists => write!(f, "Account already exists for client"),
-            DataError::NoSuchData => write!(f, "Requested data not found"),
-            DataError::DataExists => write!(f, "Data given already exists"),
-            DataError::NoSuchEntry => write!(f, "Requested entry not found"),
-            DataError::TooManyEntries => write!(f, "Exceeded a limit on a number of entries"),
-            DataError::InvalidEntryActions(ref errors) => {
+            Error::AccessDenied => write!(f, "Access denied"),
+            Error::NoSuchAccount => write!(f, "Account does not exist for client"),
+            Error::AccountExists => write!(f, "Account already exists for client"),
+            Error::NoSuchData => write!(f, "Requested data not found"),
+            Error::DataExists => write!(f, "Data given already exists"),
+            Error::NoSuchEntry => write!(f, "Requested entry not found"),
+            Error::TooManyEntries => write!(f, "Exceeded a limit on a number of entries"),
+            Error::InvalidEntryActions(ref errors) => {
                 write!(f, "Entry actions are invalid: {:?}", errors)
             }
-            DataError::NoSuchKey => write!(f, "Key does not exists"),
-            DataError::InvalidOwners => write!(f, "The list of owner keys is invalid"),
-            DataError::InvalidOperation => write!(f, "Requested operation is not allowed"),
-            DataError::InvalidSuccessor(_) => {
+            Error::NoSuchKey => write!(f, "Key does not exists"),
+            Error::InvalidOwners => write!(f, "The list of owner keys is invalid"),
+            Error::InvalidOperation => write!(f, "Requested operation is not allowed"),
+            Error::InvalidSuccessor(_) => {
                 write!(f, "Data given is not a valid successor of stored data")
             }
-            DataError::NetworkOther(ref error) => write!(f, "Error on Vault network: {}", error),
+            Error::InvalidOwnersSuccessor(_) => {
+                // TODO
+                write!(f, "Data given is not a valid successor of stored data")
+            }
+            Error::InvalidPermissionsSuccessor(_) => {
+                // TODO
+                write!(f, "Data given is not a valid successor of stored data")
+            }
+            Error::NetworkOther(ref error) => write!(f, "Error on Vault network: {}", error),
         }
     }
 }
 
-impl Error for DataError {
+impl StdError for Error {
     fn description(&self) -> &str {
         match *self {
-            DataError::AccessDenied => "Access denied",
-            DataError::NoSuchAccount => "No such account",
-            DataError::AccountExists => "Account exists",
-            DataError::NoSuchData => "No such data",
-            DataError::DataExists => "Data exists",
-            DataError::NoSuchEntry => "No such entry",
-            DataError::TooManyEntries => "Too many entries",
-            DataError::InvalidEntryActions(_) => "Invalid entry actions",
-            DataError::NoSuchKey => "No such key",
-            DataError::InvalidOwners => "Invalid owners",
-            DataError::InvalidSuccessor(_) => "Invalid data successor",
-            DataError::InvalidOperation => "Invalid operation",
-            DataError::NetworkOther(ref error) => error,
+            Error::AccessDenied => "Access denied",
+            Error::NoSuchAccount => "No such account",
+            Error::AccountExists => "Account exists",
+            Error::NoSuchData => "No such data",
+            Error::DataExists => "Data exists",
+            Error::NoSuchEntry => "No such entry",
+            Error::TooManyEntries => "Too many entries",
+            Error::InvalidEntryActions(_) => "Invalid entry actions",
+            Error::NoSuchKey => "No such key",
+            Error::InvalidOwners => "Invalid owners",
+            Error::InvalidSuccessor(_) => "Invalid data successor",
+            Error::InvalidOwnersSuccessor(_) => "Invalid owners successor",
+            Error::InvalidPermissionsSuccessor(_) => "Invalid permissions successor",
+            Error::InvalidOperation => "Invalid operation",
+            Error::NetworkOther(ref error) => error,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@
 // FIXME - write docs
 #![allow(missing_docs)]
 
+pub mod appendable_data;
 pub mod errors;
 pub mod immutable_data;
 pub mod mutable_data;

--- a/src/request.rs
+++ b/src/request.rs
@@ -7,12 +7,40 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
+use crate::appendable_data::{
+    self, AppendOnlyDataRef, AppendOnlyKind, Index, Owners, PubPermissions, UnpubPermissions, User,
+};
 use crate::immutable_data::UnpubImmutableData;
 use crate::mutable_data::{MutableDataRef, SeqMutableData, UnseqMutableData};
 use crate::MessageId;
 use crate::XorName;
-use rust_sodium::crypto::sign;
 use serde::{Deserialize, Serialize};
+use std::fmt;
+use threshold_crypto::{PublicKey, Signature};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash)]
+pub enum Requester {
+    Owner(Signature),
+    Key(PublicKey),
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash)]
+pub enum AppendOnlyData {
+    PubSeq(appendable_data::SeqAppendOnlyData<PubPermissions>),
+    UnpubSeq(appendable_data::SeqAppendOnlyData<UnpubPermissions>),
+    PubUnseq(appendable_data::UnseqAppendOnlyData<PubPermissions>),
+    UnpubUnseq(appendable_data::UnseqAppendOnlyData<UnpubPermissions>),
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash)]
+pub struct AppendOperation {
+    // Address of an AppendOnlyData object on the network.
+    address: AppendOnlyDataRef,
+    // A list of entries to append.
+    values: Vec<(Vec<u8>, Vec<u8>)>,
+    // Requester.
+    requester: Requester,
+}
 
 /// RPC Request that is sent to vaults
 #[allow(clippy::large_enum_variant)]
@@ -25,7 +53,7 @@ pub enum Request {
     GetUnseqMData {
         // Address of the mutable data to be fetched
         address: MutableDataRef,
-        requester: threshold_crypto::PublicKey,
+        requester: Requester,
         // Unique message Identifier
         message_id: MessageId,
     },
@@ -33,25 +61,162 @@ pub enum Request {
         // Mutable Data to be stored
         data: UnseqMutableData,
         // Requester public key
-        requester: sign::PublicKey,
+        requester: Requester,
         // Unique message Identifier
         message_id: MessageId,
     },
 
     GetSeqMData {
         address: MutableDataRef,
-        requester: threshold_crypto::PublicKey,
+        requester: Requester,
         message_id: MessageId,
     },
 
     PutSeqMData {
         data: SeqMutableData,
-        requester: sign::PublicKey,
+        requester: Requester,
         message_id: MessageId,
     },
-}
 
-use std::fmt;
+    // ===== Append Only Data =====
+    // Get a range of entries from an AppendOnlyData object on the network.
+    GetADataRange {
+        // Type of AppendOnlyData (published/unpublished, sequenced/unsequenced).
+        kind: AppendOnlyKind,
+
+        // Address of an AppendOnlyData object on the network.
+        address: AppendOnlyDataRef,
+
+        // Range of entries to fetch.
+        //
+        // For example, get 10 last entries:
+        // range: (Index::FromEnd(10), Index::FromEnd(0))
+        //
+        // Get all entries:
+        // range: (Index::FromStart(0), Index::FromEnd(0))
+        //
+        // Get first 5 entries:
+        // range: (Index::FromStart(0), Index::FromStart(5))
+        range: (Index, Index),
+
+        // Requester public key
+        requester: Requester,
+    },
+
+    // Get current indexes: data, owners, permissions.
+    GetADataIndexes {
+        kind: AppendOnlyKind,
+        address: AppendOnlyDataRef,
+        requester: Requester,
+    },
+
+    // Get an entry with the current index.
+    GetADataLastEntry {
+        kind: AppendOnlyKind,
+        address: AppendOnlyDataRef,
+        requester: Requester,
+    },
+
+    // Get permissions at the provided index.
+    GetADataPermissions {
+        kind: AppendOnlyKind,
+        address: AppendOnlyDataRef,
+        permissions_index: Index,
+        requester: Requester,
+    },
+
+    // Get permissions for a specified user(s).
+    GetPubADataUserPermissions {
+        kind: AppendOnlyKind,
+        address: AppendOnlyDataRef,
+        permissions_index: Index,
+        user: User,
+        requester: Requester,
+    },
+
+    // Get permissions for a specified public key.
+    GetUnpubADataUserPermissions {
+        kind: AppendOnlyKind,
+        address: AppendOnlyDataRef,
+        permissions_index: Index,
+        user: PublicKey,
+        requester: Requester,
+    },
+
+    // Get owners at the provided index.
+    GetADataOwners {
+        address: AppendOnlyDataRef,
+        kind: AppendOnlyKind,
+        owners_index: Index,
+        requester: Requester,
+    },
+
+    // Add a new `permissions` entry.
+    // The `Permissions` struct instance MUST contain a valid index.
+    AddPubADataPermissions {
+        address: AppendOnlyDataRef,
+        kind: AppendOnlyKind,
+        // New permission set
+        permissions: PubPermissions,
+        requester: Requester,
+    },
+
+    // Add a new `permissions` entry.
+    // The `Permissions` struct instance MUST contain a valid index.
+    AddUnpubADataPermissions {
+        address: AppendOnlyDataRef,
+        kind: AppendOnlyKind,
+        // New permission set
+        permissions: UnpubPermissions,
+        requester: Requester,
+    },
+
+    // Add a new `owners` entry.
+    // The `Owners` struct instance MUST contain a valid index.
+    // Only the current owner(s) can perform this action.
+    SetADataOwners {
+        kind: AppendOnlyKind,
+        address: AppendOnlyDataRef,
+        owners: Owners,
+    },
+
+    // Append operations
+    AppendPublishedSeq {
+        append: AppendOperation,
+        index: u64,
+    },
+    AppendUnpublishedSeq {
+        append: AppendOperation,
+        index: u64,
+    },
+    AppendPublishedUnseq(AppendOperation),
+    AppendUnpublishedUnseq(AppendOperation),
+
+    // Put a new AppendOnlyData on the network.
+    PutAData {
+        // AppendOnlyData to be stored
+        data: AppendOnlyData,
+        // Requester public key
+        requester: Requester,
+    },
+
+    // Get `AppendOnlyData` shell at a certain point
+    // in history (`index` refers to the list of data).
+    GetADataShell {
+        kind: AppendOnlyKind,
+        address: AppendOnlyDataRef,
+        data_index: Index,
+        requester: Requester,
+    },
+
+    // Delete an unpublished unsequenced `AppendOnlyData`.
+    // Only the current owner(s) can perform this action.
+    DeleteUnseqAData(AppendOnlyDataRef),
+    // Delete an unpublished sequenced `AppendOnlyData`.
+    // This operation MUST return an error if applied to published AppendOnlyData.
+    // Only the current owner(s) can perform this action.
+    DeleteSeqAData(AppendOnlyDataRef),
+}
 
 impl fmt::Debug for Request {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -63,6 +228,8 @@ impl fmt::Debug for Request {
             Request::PutUnseqMData { .. } => "Request::PutUnseqMData",
             Request::GetSeqMData { .. } => "Request::GetSeqMData",
             Request::PutSeqMData { .. } => "Request::PutSeqMData",
+            // TODO
+            ref _x => "Request",
         };
         write!(f, "{}", printable)
     }


### PR DESCRIPTION
This PR implements some of the `AppendOnlyData` functions as they are described in the RFC.
Currently, it lacks the permissions handling and response types.