### PR TITLE
Jenkins Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ env:
     - PATH=$PATH:$HOME/.cargo/bin
 os:
   - linux
-  - osx
-  - windows
 language: rust
 sudo: false
 cache:
@@ -17,9 +15,7 @@ before_script:
   - rustup component add rustfmt clippy
 script:
   - cargo fmt -- --check
-  - if [ "${TRAVIS_OS_NAME}" = linux ]; then
-      cargo clippy --verbose --release --all-targets ;
-    fi
+  - cargo clippy --verbose --release --all-targets ;
   - cargo test --verbose --release
 before_cache:
   - cargo prune

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -29,6 +29,8 @@ COPY . .
 
 USER maidsafe:maidsafe
 ENV CARGO_TARGET_DIR=/target
-RUN cargo test --verbose --release && \
+RUN rustup component add rustfmt clippy && \
+    cargo clippy --verbose --release --all-targets && \
+    cargo test --verbose --release && \
     find /target/release/ -maxdepth 1 -type f -exec rm '{}' \;
 ENTRYPOINT ["fixuid", "-q"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,34 @@
+FROM rust:latest
+
+RUN addgroup --gid 1000 maidsafe && \
+    adduser --uid 1000 --ingroup maidsafe --home /home/maidsafe --shell /bin/sh --disabled-password --gecos "" maidsafe && \
+    # The parent container sets this to the 'staff' group, which causes problems
+    # with reading code stored in Cargo's registry.
+    chgrp -R maidsafe /usr/local
+
+# Install fixuid for dealing with permissions issues with mounted volumes.
+# We could perhaps put this into a base container at a later stage.
+RUN USER=maidsafe && \
+    GROUP=maidsafe && \
+    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.4/fixuid-0.4-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
+    chown root:root /usr/local/bin/fixuid && \
+    chmod 4755 /usr/local/bin/fixuid && \
+    mkdir -p /etc/fixuid && \
+    printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
+
+RUN apt-get update -y && \
+    mkdir /target && \
+    chown maidsafe:maidsafe /target && \
+    mkdir /usr/src/safe-nd && \
+    chown maidsafe:maidsafe /usr/src/safe-nd && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/safe-nd
+COPY . .
+
+USER maidsafe:maidsafe
+ENV CARGO_TARGET_DIR=/target
+RUN cargo test --verbose --release && \
+    find /target/release/ -maxdepth 1 -type f -exec rm '{}' \;
+ENTRYPOINT ["fixuid", "-q"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,20 @@
+stage('build & test') {
+    parallel mock_linux: {
+        node('docker') {
+            checkout(scm)
+            sh("make test")
+        }
+    },
+    windows: {
+        node('windows') {
+            checkout(scm)
+            sh("make test")
+        }
+    },
+    osx: {
+        node('osx') {
+            checkout(scm)
+            sh("make test")
+        }
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,25 @@
 SHELL := /bin/bash
 SAFE_ND_VERSION := $(shell grep "^version" < Cargo.toml | head -n 1 | awk '{ print $$3 }' | sed 's/\"//g')
+USER_ID := $(shell id -u)
+GROUP_ID := $(shell id -g)
+UNAME_S := $(shell uname -s)
+PWD := $(shell echo $$PWD)
+UUID := $(shell uuidgen | sed 's/-//g')
 
 build-container:
 	rm -rf target/
 	docker rmi -f maidsafe/safe-nd-build:${SAFE_ND_VERSION}
 	docker build -f Dockerfile.build -t maidsafe/safe-nd-build:${SAFE_ND_VERSION} .
+
+test:
+ifeq ($(UNAME_S),Linux)
+	docker run --name "safe-nd-build-${UUID}" -v "${PWD}":/usr/src/safe-nd:Z \
+		-u ${USER_ID}:${GROUP_ID} \
+		maidsafe/safe-nd-build:${SAFE_ND_VERSION} \
+		/bin/bash -c "cargo fmt -- --check --verbose && cargo clippy --verbose --release --all-targets && cargo test --verbose --release"
+	docker cp "safe-nd-build-${UUID}":/target .
+	docker rm "safe-nd-build-${UUID}"
+else
+	cargo fmt -- --check
+	cargo test --verbose --release
+endif

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+SHELL := /bin/bash
+SAFE_ND_VERSION := $(shell grep "^version" < Cargo.toml | head -n 1 | awk '{ print $$3 }' | sed 's/\"//g')
+
+build-container:
+	rm -rf target/
+	docker rmi -f maidsafe/safe-nd-build:${SAFE_ND_VERSION}
+	docker build -f Dockerfile.build -t maidsafe/safe-nd-build:${SAFE_ND_VERSION} .


### PR DESCRIPTION
This adds a Jenkins build for safe-nd. Right now it's just a simple one stage pipeline with build and test. We can expand as needed.

It also removes the macOS and Windows builds because these are now covered by Jenkins. Linux on Travis is retained for open source alignment.