### PR TITLE
Remove Requester and overhaul perms handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ hex_fmt = "~0.3.0"
 rand = "~0.6.5"
 serde = { version = "~1.0.92", features = ["derive"] }
 sha3 = "~0.8.2"
-# threshold_crypto = "~0.3.1"
-threshold_crypto = { git = "https://github.com/nbaksalyar/threshold_crypto.git", branch = "pks-copy" }
+threshold_crypto = { git = "https://github.com/poanetwork/threshold_crypto.git", branch = "master" }
 tiny-keccak = "~1.4.2"
 unwrap = "~1.2.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,14 +84,15 @@ pub use immutable_data::{
     Address as IDataAddress, ImmutableData, UnpubImmutableData, MAX_IMMUTABLE_DATA_SIZE_IN_BYTES,
 };
 pub use mutable_data::{
-    Address as MDataAddress, MutableData, PermissionSet as MDataPermissionSet,
-    SeqEntryAction as MDataSeqEntryAction, SeqEntryActions as MDataSeqEntryActions, SeqMutableData,
+    Action as MDataAction, Address as MDataAddress, MutableData,
+    PermissionSet as MDataPermissionSet, SeqEntryAction as MDataSeqEntryAction,
+    SeqEntryActions as MDataSeqEntryActions, SeqMutableData,
     UnseqEntryAction as MDataUnseqEntryAction, UnseqEntryActions as MDataUnseqEntryActions,
     UnseqMutableData, Value as MDataValue,
 };
 pub use public_key::{PublicKey, Signature};
-pub use request::{Request, Requester};
-pub use response::Response;
+pub use request::Request;
+pub use response::{Response, Transaction};
 pub use sha3::Sha3_512 as Ed25519Digest;
 
 use hex_fmt::HexFmt;

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -133,6 +133,24 @@ pub enum Signature {
     BlsShare(threshold_crypto::SignatureShare),
 }
 
+impl From<threshold_crypto::Signature> for Signature {
+    fn from(sig: threshold_crypto::Signature) -> Self {
+        Signature::Bls(sig)
+    }
+}
+
+impl From<ed25519_dalek::Signature> for Signature {
+    fn from(sig: ed25519_dalek::Signature) -> Self {
+        Signature::Ed25519(sig)
+    }
+}
+
+impl From<threshold_crypto::SignatureShare> for Signature {
+    fn from(sig: threshold_crypto::SignatureShare) -> Self {
+        Signature::BlsShare(sig)
+    }
+}
+
 #[allow(clippy::derive_hash_xor_eq)]
 impl Hash for Signature {
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/src/request.rs
+++ b/src/request.rs
@@ -11,18 +11,11 @@ use crate::{
     ADataAddress, ADataIndex, ADataOwner, ADataPubPermissions, ADataUnpubPermissions, ADataUser,
     AppPermissions, AppendOnlyData as AppendOnlyTrait, Coins, IDataAddress, ImmutableData,
     MDataAddress, MDataPermissionSet, MDataSeqEntryAction, MDataUnseqEntryAction,
-    PubSeqAppendOnlyData, PubUnseqAppendOnlyData, PublicKey, SeqMutableData, Signature,
-    UnpubImmutableData, UnpubSeqAppendOnlyData, UnpubUnseqAppendOnlyData, UnseqMutableData,
-    XorName,
+    PubSeqAppendOnlyData, PubUnseqAppendOnlyData, PublicKey, SeqMutableData, UnpubImmutableData,
+    UnpubSeqAppendOnlyData, UnpubUnseqAppendOnlyData, UnseqMutableData, XorName,
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fmt};
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash)]
-pub enum Requester {
-    Owner(Signature),
-    Key(PublicKey),
-}
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash)]
 pub enum AppendOnlyData {


### PR DESCRIPTION
Requester has been made redundant with the change in the way we approach permissions handling client/app keys. This PR also exposes some of the necessary symbols from internal modules and fixes the `threshold_crypto` dependency.