### PR TITLE
refactor/response: remove TransferCoins response

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -85,7 +85,6 @@ pub enum Response {
     //
     // ===== Coins =====
     //
-    TransferCoins(Result<()>),
     GetTransaction(Result<Transaction>),
     GetBalance(Result<Coins>),
     //
@@ -134,7 +133,6 @@ impl fmt::Debug for Response {
                 MutateUnseqMDataEntries(..) => "Response::MutateUnseqMDataEntries",
                 GetSeqMDataValue(..) => "Response::GetSeqMDataValue",
                 GetUnseqMDataValue(..) => "Response::GetUnseqMDataValue",
-                TransferCoins(..) => "Response::TransferCoins",
                 GetTransaction(..) => "Response::GetTransaction",
                 GetBalance(..) => "Response::GetBalance",
                 ListAuthKeysAndVersion(..) => "Response::ListAuthKeysAndVersion",


### PR DESCRIPTION
We shouldn't have a response variant for TransferCoins: the request should be fire-and-forget and we should get the transaction status by sending a GetTransaction request.

Fixes https://github.com/maidsafe/safe_client_libs/issues/868 