### PR TITLE
refactor/encode: introduces multibase z-base-32 encode/decode by swapping base64 encode/decode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ version = "0.1.0"
 bincode = "=1.1.4"
 ed25519-dalek = "~0.9.1"
 hex_fmt = "~0.3.0"
+multibase = "~0.6.0"
 rand = "~0.6.5"
 serde = { version = "~1.0.92", features = ["derive"] }
 sha3 = "~0.8.2"
 threshold_crypto = { git = "https://github.com/poanetwork/threshold_crypto.git", branch = "master" }
 tiny-keccak = "~1.4.2"
 unwrap = "~1.2.1"
-base64 = "0.10.1"
 
 [dev-dependencies]
 hex = "~0.3.2"

--- a/src/coins.rs
+++ b/src/coins.rs
@@ -71,7 +71,7 @@ impl FromStr for Coins {
             let units = itr
                 .next()
                 .and_then(|s| s.parse::<u64>().ok())
-                .ok_or(Error::FailedToParseCoins)?;
+                .ok_or_else(|| Error::FailedToParse("Can't parse coin units".to_string()))?;
 
             units
                 .checked_mul(COIN_TO_RAW_CONVERSION)
@@ -86,7 +86,7 @@ impl FromStr for Coins {
             } else {
                 let parsed_remainder = remainder_str
                     .parse::<u64>()
-                    .map_err(|_| Error::FailedToParseCoins)?;
+                    .map_err(|_| Error::FailedToParse("Can't parse coin remainder".to_string()))?;
 
                 let remainder_conversion = COIN_TO_RAW_POWER_OF_10_CONVERSION
                     .checked_sub(remainder_str.len() as u32)
@@ -150,9 +150,22 @@ mod tests {
             unwrap!(Coins::from_str("4294967295.9999999990000")),
         );
 
-        assert_eq!(Err(Error::FailedToParseCoins), Coins::from_str("a"));
-        assert_eq!(Err(Error::FailedToParseCoins), Coins::from_str("0.a"));
-        assert_eq!(Err(Error::FailedToParseCoins), Coins::from_str("0.0.0"));
+        assert_eq!(
+            Err(Error::FailedToParse("Can't parse coin units".to_string())),
+            Coins::from_str("a")
+        );
+        assert_eq!(
+            Err(Error::FailedToParse(
+                "Can't parse coin remainder".to_string()
+            )),
+            Coins::from_str("0.a")
+        );
+        assert_eq!(
+            Err(Error::FailedToParse(
+                "Can't parse coin remainder".to_string()
+            )),
+            Coins::from_str("0.0.0")
+        );
         assert_eq!(Err(Error::LossOfPrecision), Coins::from_str("0.0000000009"));
         assert_eq!(Err(Error::ExcessiveValue), Coins::from_str("4294967296"));
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -66,8 +66,7 @@ pub enum Error {
     /// [the maximum value for `Coins`](constant.MAX_COINS_VALUE.html).
     ExcessiveValue,
     /// Failed to parse the string as [`Coins`](struct.Coins.html).
-    FailedToParseCoins,
-    FailedToParseIdentity(String),
+    FailedToParse(String),
     /// Transaction ID already exists.
     TransactionIdExists,
     /// Insufficient coins.
@@ -120,9 +119,8 @@ impl Display for Error {
                 f,
                 "Overflow on number of coins (check the MAX_COINS_VALUE const)"
             ),
-            Error::FailedToParseCoins => write!(f, "Failed to parse number of coins from a string"),
-            Error::FailedToParseIdentity(ref error) => {
-                write!(f, "Failed to parse identity from a string: {}", error)
+            Error::FailedToParse(ref error) => {
+                write!(f, "Failed to parse from a string: {}", error)
             }
             Error::TransactionIdExists => write!(f, "Transaction with a given ID already exists"),
             Error::InsufficientBalance => write!(f, "Not enough coins to complete this operation"),
@@ -155,8 +153,7 @@ impl error::Error for Error {
             Error::ExcessiveValue => {
                 "Overflow on number of coins (check the MAX_COINS_VALUE const)"
             }
-            Error::FailedToParseCoins => "Failed to parse number of coins from a string",
-            Error::FailedToParseIdentity(_) => "Failed to parse identity from a string",
+            Error::FailedToParse(_) => "Failed to parse entity",
             Error::TransactionIdExists => "Transaction with a given ID already exists",
             Error::InsufficientBalance => "Not enough coins to complete this operation",
         }

--- a/src/identity/app.rs
+++ b/src/identity/app.rs
@@ -8,7 +8,10 @@
 // Software.
 
 use super::client::Keypair;
-use crate::{ClientFullId, ClientPublicId, Ed25519Digest, Error, PublicKey, Signature, XorName};
+use crate::{
+    utils, ClientFullId, ClientPublicId, Ed25519Digest, Error, PublicKey, Signature, XorName,
+};
+use multibase::Decodable;
 use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug, Display, Formatter};
@@ -100,14 +103,14 @@ impl PublicId {
         &self.owner
     }
 
-    /// Returns the PublicId serialised and encoded in standard base64.
-    pub fn encode_to_base64(&self) -> String {
-        super::encode_to_base64(&self)
+    /// Returns the PublicId serialised and encoded in z-base-32.
+    pub fn encode_to_zbase32(&self) -> String {
+        utils::encode(&self)
     }
 
-    /// Create from standard base64 encoded string.
-    pub fn decode_from_base64<T: ?Sized + AsRef<[u8]>>(encoded: &T) -> Result<Self, Error> {
-        super::decode_from_base64(encoded)
+    /// Create from z-base-32 encoded string.
+    pub fn decode_from_zbase32<T: Decodable>(encoded: T) -> Result<Self, Error> {
+        utils::decode(encoded)
     }
 }
 

--- a/src/identity/client.rs
+++ b/src/identity/client.rs
@@ -8,8 +8,9 @@
 // Software.
 
 use super::{BlsKeypair, BlsKeypairShare};
-use crate::{Ed25519Digest, Error, PublicKey, Signature, XorName};
+use crate::{utils, Ed25519Digest, Error, PublicKey, Signature, XorName};
 use ed25519_dalek::Keypair as Ed25519Keypair;
+use multibase::Decodable;
 use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::{self, Debug, Display, Formatter};
@@ -147,14 +148,14 @@ impl PublicId {
         Self { name, public_key }
     }
 
-    /// Returns the PublicId serialised and encoded in standard base64.
-    pub fn encode_to_base64(&self) -> String {
-        super::encode_to_base64(&self)
+    /// Returns the PublicId serialised and encoded in z-base-32.
+    pub fn encode_to_zbase32(&self) -> String {
+        utils::encode(&self)
     }
 
-    /// Create from standard base64 encoded string.
-    pub fn decode_from_base64<T: ?Sized + AsRef<[u8]>>(encoded: &T) -> Result<Self, Error> {
-        super::decode_from_base64(encoded)
+    /// Create from z-base-32 encoded string.
+    pub fn decode_from_zbase32<T: Decodable>(encoded: T) -> Result<Self, Error> {
+        utils::decode(encoded)
     }
 }
 

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -11,14 +11,14 @@ pub mod app;
 pub mod client;
 pub mod node;
 
-use crate::{Error, XorName};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use crate::{utils, Result, XorName};
+use multibase::Decodable;
+use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug, Display, Formatter};
 use threshold_crypto::{
     serde_impl::SerdeSecret, PublicKey as BlsPublicKey, PublicKeyShare as BlsPublicKeyShare,
     SecretKey as BlsSecretKey, SecretKeyShare as BlsSecretKeyShare,
 };
-use unwrap::unwrap;
 
 /// An enum representing the identity of a network Node or Client.
 ///
@@ -41,6 +41,16 @@ impl PublicId {
             PublicId::Client(pub_id) => pub_id.name(),
             PublicId::App(pub_id) => pub_id.owner_name(),
         }
+    }
+
+    /// Returns the PublicId serialised and encoded in z-base-32.
+    pub fn encode_to_zbase32(&self) -> String {
+        utils::encode(&self)
+    }
+
+    /// Create from z-base-32 encoded string.
+    pub fn decode_from_zbase32<T: Decodable>(encoded: T) -> Result<Self> {
+        utils::decode(encoded)
     }
 }
 
@@ -73,72 +83,70 @@ struct BlsKeypairShare {
     pub public: BlsPublicKeyShare,
 }
 
-fn encode_to_base64<T: Serialize>(data: &T) -> String {
-    let serialised = unwrap!(bincode::serialize(&data));
-    base64::encode(&serialised)
-}
-
-fn decode_from_base64<I: ?Sized + AsRef<[u8]>, O: DeserializeOwned>(
-    encoded: &I,
-) -> Result<O, Error> {
-    let decoded =
-        base64::decode(encoded).map_err(|e| Error::FailedToParseIdentity(e.to_string()))?;
-    Ok(bincode::deserialize(&decoded).map_err(|e| Error::FailedToParseIdentity(e.to_string()))?)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ClientFullId;
+    use crate::{ClientFullId, Error};
     use unwrap::unwrap;
 
     #[test]
-    fn encode_client_public_id_to_base64() {
+    fn zbase32_encode_decode_client_public_id() {
         let mut rng = rand::thread_rng();
         let id = client::FullId::new_ed25519(&mut rng);
         assert_eq!(
-            unwrap!(client::PublicId::decode_from_base64(
-                &id.public_id().encode_to_base64()
+            unwrap!(client::PublicId::decode_from_zbase32(
+                &id.public_id().encode_to_zbase32()
             )),
             *id.public_id()
         );
 
         let node_id = node::FullId::new(&mut rng);
-        assert!(
-            match client::PublicId::decode_from_base64(&node_id.public_id().encode_to_base64()) {
-                Err(Error::FailedToParseIdentity(_)) => true,
-                _ => false,
-            }
-        );
-        assert!(client::PublicId::decode_from_base64("sdkjf832939fjs").is_err());
+        assert!(match client::PublicId::decode_from_zbase32(
+            &node_id.public_id().encode_to_zbase32()
+        ) {
+            Err(Error::FailedToParse(_)) => true,
+            _ => false,
+        });
+        assert!(client::PublicId::decode_from_zbase32("sdkjf832939fjs").is_err());
     }
 
     #[test]
-    fn encode_node_public_id_to_base64() {
+    fn zbase32_encode_decode_node_public_id() {
         let mut rng = rand::thread_rng();
         let mut id = node::FullId::new(&mut rng);
         let bls_secret_key = threshold_crypto::SecretKeySet::random(1, &mut rng);
         id.set_bls_keys(bls_secret_key.secret_key_share(0));
         assert_eq!(
-            unwrap!(node::PublicId::decode_from_base64(
-                &id.public_id().encode_to_base64()
+            unwrap!(node::PublicId::decode_from_zbase32(
+                &id.public_id().encode_to_zbase32()
             )),
             *id.public_id()
         );
-        assert!(node::PublicId::decode_from_base64("7djsk38").is_err());
+        assert!(node::PublicId::decode_from_zbase32("7djsk38").is_err());
     }
 
     #[test]
-    fn encode_app_public_id_to_base64() {
+    fn zbase32_encode_decode_app_public_id() {
         let mut rng = rand::thread_rng();
         let owner = ClientFullId::new_ed25519(&mut rng);
         let id = app::FullId::new_ed25519(&mut rng, owner.public_id().clone());
         assert_eq!(
-            unwrap!(app::PublicId::decode_from_base64(
-                &id.public_id().encode_to_base64()
+            unwrap!(app::PublicId::decode_from_zbase32(
+                &id.public_id().encode_to_zbase32()
             )),
             *id.public_id()
         );
-        assert!(app::PublicId::decode_from_base64("7od8fh2").is_err());
+        assert!(app::PublicId::decode_from_zbase32("7od8fh2").is_err());
+    }
+
+    #[test]
+    fn zbase32_encode_decode_enum_public_id() {
+        let mut rng = rand::thread_rng();
+        let id = PublicId::Client(client::FullId::new_ed25519(&mut rng).public_id().clone());
+        assert_eq!(
+            id,
+            unwrap!(PublicId::decode_from_zbase32(&id.encode_to_zbase32()))
+        );
+        assert!(PublicId::decode_from_zbase32("c419cxim9").is_err());
     }
 }

--- a/src/identity/node.rs
+++ b/src/identity/node.rs
@@ -8,8 +8,9 @@
 // Software.
 
 use super::BlsKeypairShare;
-use crate::{Ed25519Digest, Error, PublicKey, Signature, XorName};
+use crate::{utils, Ed25519Digest, Error, PublicKey, Signature, XorName};
 use ed25519_dalek::{Keypair as Ed25519Keypair, PublicKey as Ed25519PublicKey};
+use multibase::Decodable;
 use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::{self, Debug, Display, Formatter};
@@ -124,14 +125,14 @@ impl PublicId {
         &self.bls
     }
 
-    /// Returns the PublicId serialised and encoded in standard base64.
-    pub fn encode_to_base64(&self) -> String {
-        super::encode_to_base64(&self)
+    /// Returns the PublicId serialised and encoded in z-base-32.
+    pub fn encode_to_zbase32(&self) -> String {
+        utils::encode(&self)
     }
 
-    /// Create from standard base64 encoded string.
-    pub fn decode_from_base64<T: ?Sized + AsRef<[u8]>>(encoded: &T) -> Result<Self, Error> {
-        super::decode_from_base64(encoded)
+    /// Create from z-base-32 encoded string.
+    pub fn decode_from_zbase32<T: Decodable>(encoded: T) -> Result<Self, Error> {
+        utils::decode(encoded)
     }
 }
 

--- a/src/mutable_data.rs
+++ b/src/mutable_data.rs
@@ -7,7 +7,8 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use crate::{EntryError, Error, PublicKey, Request, Result, XorName};
+use crate::{utils, EntryError, Error, PublicKey, Request, Result, XorName};
+use multibase::Decodable;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{btree_map::Entry, BTreeMap, BTreeSet},
@@ -656,6 +657,16 @@ impl Address {
             Address::Unseq { tag, .. } | Address::Seq { tag, .. } => *tag,
         }
     }
+
+    /// Returns the Address serialised and encoded in z-base-32.
+    pub fn encode_to_zbase32(&self) -> String {
+        utils::encode(&self)
+    }
+
+    /// Create from z-base-32 encoded string.
+    pub fn decode_from_zbase32<T: Decodable>(encoded: T) -> Result<Self> {
+        utils::decode(encoded)
+    }
 }
 
 #[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Serialize, Deserialize, Debug)]
@@ -760,5 +771,19 @@ impl UnseqEntryActions {
 impl Into<BTreeMap<Vec<u8>, UnseqEntryAction>> for UnseqEntryActions {
     fn into(self) -> BTreeMap<Vec<u8>, UnseqEntryAction> {
         self.actions
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{Address, XorName};
+    use unwrap::unwrap;
+    #[test]
+    fn zbase32_encode_decode_mdata_address() {
+        let name = XorName(rand::random());
+        let address = Address::new_seq(name, 15000);
+        let encoded = address.encode_to_zbase32();
+        let decoded = unwrap!(self::Address::decode_from_zbase32(&encoded));
+        assert_eq!(address, decoded);
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -8,8 +8,8 @@
 // Software.
 
 use crate::{
-    request::AppendOnlyData, ADataIndices, ADataOwner, ADataPubPermissionSet, ADataPubPermissions,
-    ADataUnpubPermissionSet, ADataUnpubPermissions, AppPermissions, Coins, IDataKind,
+    AData, ADataIndices, ADataOwner, ADataPubPermissionSet, ADataPubPermissions,
+    ADataUnpubPermissionSet, ADataUnpubPermissions, AppPermissions, Coins, Entries, IDataKind,
     MDataPermissionSet, MDataValue, PublicKey, Result, SeqMutableData, UnseqMutableData,
 };
 use serde::{Deserialize, Serialize};
@@ -66,10 +66,10 @@ pub enum Response {
     // ===== Append Only Data =====
     //
     PutAData(Result<()>),
-    GetAData(Result<AppendOnlyData>),
-    GetADataShell(Result<AppendOnlyData>),
+    GetAData(Result<AData>),
+    GetADataShell(Result<AData>),
     GetADataOwners(Result<ADataOwner>),
-    GetADataRange(Result<Vec<(Vec<u8>, Vec<u8>)>>),
+    GetADataRange(Result<Entries>),
     GetADataIndices(Result<ADataIndices>),
     GetADataLastEntry(Result<(Vec<u8>, Vec<u8>)>),
     GetUnpubADataPermissionAtIndex(Result<ADataUnpubPermissions>),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,49 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+use crate::{Error, MessageId, PublicKey, Request, Result, Signature};
+use bincode;
+use multibase::{self, Base, Decodable};
+use serde::{de::DeserializeOwned, Serialize};
+use unwrap::unwrap;
+
+/// Verify that a signature is valid for a given Request + MessageId combination
+pub fn verify_signature(
+    signature: &Signature,
+    public_key: &PublicKey,
+    request: &Request,
+    message_id: &MessageId,
+) -> Result<()> {
+    let message = serialise(&(request, *message_id));
+    public_key.verify(signature, message)
+}
+
+/// Wrapper for raw bincode::serialize
+pub(crate) fn serialise<T: Serialize>(data: &T) -> Vec<u8> {
+    unwrap!(bincode::serialize(data))
+}
+
+/// Wrapper for z-Base-32 multibase::encode
+pub(crate) fn encode<T: Serialize>(data: &T) -> String {
+    let serialised = serialise(&data);
+    multibase::encode(Base::Base32z, &serialised)
+}
+
+/// Wrapper for z-Base-32 multibase::decode
+pub(crate) fn decode<I: Decodable, O: DeserializeOwned>(encoded: I) -> Result<O> {
+    let (base, decoded) =
+        multibase::decode(encoded).map_err(|e| Error::FailedToParse(e.to_string()))?;
+    if base != Base::Base32z {
+        return Err(Error::FailedToParse(format!(
+            "Expected z-base-32 encoding, but got {:?}",
+            base
+        )));
+    }
+    Ok(bincode::deserialize(&decoded).map_err(|e| Error::FailedToParse(e.to_string()))?)
+}


### PR DESCRIPTION
Resolves issue #44 

- Removed base64 crate from dependencies
- Added utils module containing wrappers for serialization and encode/decode
- Changed all occurrences of previous base64 encode/decode to the new z-base-32 encode/decode 
   wrappers
- Implemented encode/decode helper functions and tests for Xorname, PublicKey, 
  AppPublicId,ClientPublicId, NodePublicId, PublicId, ADataAddress, IDataAddress, MDataAddress

  This commit also includes a minor refactor for AppendOnly Data
- Moved AData impl from requests module to append_only_data module
- Introduced two macros to reduce LOC
- Moved permissions checking from types to AData enum
- Refactored return type for in_range function