### PR TITLE
refactor/data: refactor data types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,9 +67,9 @@ mod response;
 mod utils;
 
 pub use append_only_data::{
-    AData, Action as ADataAction, Address as ADataAddress, AppendOnlyData,
-    AppendOperation as ADataAppend, Entries, Index as ADataIndex, Indices as ADataIndices,
-    Owner as ADataOwner, PubPermissionSet as ADataPubPermissionSet,
+    Action as ADataAction, Address as ADataAddress, AppendOnlyData, AppendOperation as ADataAppend,
+    Data as AData, Entries as ADataEntries, Index as ADataIndex, Indices as ADataIndices,
+    Kind as ADataKind, Owner as ADataOwner, PubPermissionSet as ADataPubPermissionSet,
     PubPermissions as ADataPubPermissions, PubSeqAppendOnlyData, PubUnseqAppendOnlyData,
     SeqAppendOnly, UnpubPermissionSet as ADataUnpubPermissionSet,
     UnpubPermissions as ADataUnpubPermissions, UnpubSeqAppendOnlyData, UnpubUnseqAppendOnlyData,
@@ -84,11 +84,11 @@ pub use identity::{
     PublicId,
 };
 pub use immutable_data::{
-    Address as IDataAddress, ImmutableData, Kind as IDataKind, UnpubImmutableData,
-    MAX_IMMUTABLE_DATA_SIZE_IN_BYTES,
+    Address as IDataAddress, Data as IData, Kind as IDataKind, PubImmutableData,
+    UnpubImmutableData, MAX_IMMUTABLE_DATA_SIZE_IN_BYTES,
 };
 pub use mutable_data::{
-    Action as MDataAction, Address as MDataAddress, MutableData,
+    Action as MDataAction, Address as MDataAddress, Data as MData, Kind as MDataKind, MutableData,
     PermissionSet as MDataPermissionSet, SeqEntryAction as MDataSeqEntryAction,
     SeqEntryActions as MDataSeqEntryActions, SeqMutableData,
     UnseqEntryAction as MDataUnseqEntryAction, UnseqEntryActions as MDataUnseqEntryActions,
@@ -108,6 +108,13 @@ use rand::{
 };
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug, Display, Formatter};
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
+pub enum Data {
+    Immutable(IData),
+    Mutable(MData),
+    AppendOnly(AData),
+}
 
 /// Permissions for an app stored by the Elders.
 #[derive(

--- a/src/request.rs
+++ b/src/request.rs
@@ -12,9 +12,9 @@ mod account_data;
 pub use self::account_data::{AccountData, MAX_ACCOUNT_DATA_BYTES};
 use crate::{
     AData, ADataAddress, ADataAppend, ADataIndex, ADataOwner, ADataPubPermissions,
-    ADataUnpubPermissions, ADataUser, AppPermissions, Coins, IDataAddress, IDataKind, MDataAddress,
-    MDataPermissionSet, MDataSeqEntryActions, MDataUnseqEntryActions, PublicKey, SeqMutableData,
-    UnseqMutableData, XorName,
+    ADataUnpubPermissions, ADataUser, AppPermissions, Coins, IData, IDataAddress, MData,
+    MDataAddress, MDataPermissionSet, MDataSeqEntryActions, MDataUnseqEntryActions, PublicKey,
+    XorName,
 };
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -28,14 +28,13 @@ pub enum Request {
     //
     // ===== Immutable Data =====
     //
-    PutIData(IDataKind),
+    PutIData(IData),
     GetIData(IDataAddress),
     DeleteUnpubIData(IDataAddress),
     //
     // ===== Mutable Data =====
     //
-    PutUnseqMData(UnseqMutableData),
-    PutSeqMData(SeqMutableData),
+    PutMData(MData),
     GetMData(MDataAddress),
     GetMDataValue {
         address: MDataAddress,
@@ -219,8 +218,7 @@ impl fmt::Debug for Request {
                 GetIData(_) => "Request::GetIData",
                 DeleteUnpubIData(_) => "Request::DeleteUnpubIData",
                 // MData
-                PutUnseqMData(_) => "Request::PutUnseqMData",
-                PutSeqMData(_) => "Request::PutSeqMData",
+                PutMData(_) => "Request::PutMData",
                 GetMData(_) => "Request::GetMData",
                 GetMDataValue { .. } => "Request::GetMDataValue",
                 DeleteMData(_) => "Request::DeleteMData",

--- a/src/response.rs
+++ b/src/response.rs
@@ -8,9 +8,9 @@
 // Software.
 
 use crate::{
-    AData, ADataIndices, ADataOwner, ADataPubPermissionSet, ADataPubPermissions,
-    ADataUnpubPermissionSet, ADataUnpubPermissions, AppPermissions, Coins, Entries, IDataKind,
-    MDataPermissionSet, MDataValue, PublicKey, Result, SeqMutableData, Signature, UnseqMutableData,
+    AData, ADataEntries, ADataIndices, ADataOwner, ADataPubPermissionSet, ADataPubPermissions,
+    ADataUnpubPermissionSet, ADataUnpubPermissions, AppPermissions, Coins, IData, MData,
+    MDataPermissionSet, MDataValue, PublicKey, Result, Signature,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
@@ -34,15 +34,12 @@ pub enum Response {
     //
     // ===== Immutable Data =====
     //
-    GetIData(Result<IDataKind>),
+    GetIData(Result<IData>),
     //
     // ===== Mutable Data =====
     //
-    /// Get unsequenced Mutable Data.
-    GetUnseqMData(Result<UnseqMutableData>),
-    GetSeqMData(Result<SeqMutableData>),
-    GetSeqMDataShell(Result<SeqMutableData>),
-    GetUnseqMDataShell(Result<UnseqMutableData>),
+    GetMData(Result<MData>),
+    GetMDataShell(Result<MData>),
     GetMDataVersion(Result<u64>),
     ListUnseqMDataEntries(Result<BTreeMap<Vec<u8>, Vec<u8>>>),
     ListSeqMDataEntries(Result<BTreeMap<Vec<u8>, MDataValue>>),
@@ -59,7 +56,7 @@ pub enum Response {
     GetAData(Result<AData>),
     GetADataShell(Result<AData>),
     GetADataOwners(Result<ADataOwner>),
-    GetADataRange(Result<Entries>),
+    GetADataRange(Result<ADataEntries>),
     GetADataIndices(Result<ADataIndices>),
     GetADataLastEntry(Result<(Vec<u8>, Vec<u8>)>),
     GetUnpubADataPermissionAtIndex(Result<ADataUnpubPermissions>),
@@ -98,10 +95,8 @@ impl fmt::Debug for Response {
                 // IData
                 GetIData(..) => "Response::GetIData",
                 // MData
-                GetUnseqMData(..) => "Response::GetUnseqMData",
-                GetSeqMData(..) => "Response::GetSeqMData",
-                GetSeqMDataShell(..) => "Response::GetMDataShell",
-                GetUnseqMDataShell(..) => "Response::GetMDataShell",
+                GetMData(..) => "Response::GetMData",
+                GetMDataShell(..) => "Response::GetMDataShell",
                 GetMDataVersion(..) => "Response::GetMDataVersion",
                 ListUnseqMDataEntries(..) => "Response::ListUnseqMDataEntries",
                 ListSeqMDataEntries(..) => "Response::ListSeqMDataEntries",


### PR DESCRIPTION
Addresses this [forum feedback](https://safenetforum.org/t/rfc-54-published-and-unpublished-datatype/28620/17), and makes the data types easier to work with in SCL (based on inefficiencies I noticed while working with the new MData types in https://github.com/maidsafe/safe_client_libs/issues/814).