### PR TITLE
Change PutAccount RPC

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -76,6 +76,8 @@ pub enum Error {
     TransactionIdExists,
     /// Insufficient coins.
     InsufficientBalance,
+    /// Expected data size exceeded.
+    ExceededSize,
 }
 
 impl<T: Into<String>> From<T> for Error {
@@ -131,6 +133,7 @@ impl Display for Error {
             Error::InsufficientBalance => write!(f, "Not enough coins to complete this operation"),
             Error::DuplicateMessageId => write!(f, "MessageId already exists"),
             Error::UnexpectedDataReturned => write!(f, "Unexpected data variant"),
+            Error::ExceededSize => write!(f, "Size of the structure exceeds the limit"),
         }
     }
 }
@@ -165,6 +168,7 @@ impl error::Error for Error {
             Error::InsufficientBalance => "Not enough coins to complete this operation",
             Error::DuplicateMessageId => "MessageId already exists",
             Error::UnexpectedDataReturned => "Unexpected data variant",
+            Error::ExceededSize => "Exceeded the size limit",
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ pub use mutable_data::{
     UnseqMutableData, Value as MDataValue,
 };
 pub use public_key::{PublicKey, Signature};
-pub use request::Request;
+pub use request::{AccountData, Request, MAX_ACCOUNT_DATA_BYTES};
 pub use response::{Response, Transaction};
 pub use sha3::Sha3_512 as Ed25519Digest;
 pub use utils::verify_signature;

--- a/src/request/account_data.rs
+++ b/src/request/account_data.rs
@@ -1,0 +1,114 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+use crate::{Error, PublicKey, Result, Signature, XorName};
+use serde::{Deserialize, Serialize};
+
+/// Account packet size is limited .
+pub const MAX_ACCOUNT_DATA_BYTES: usize = 1024 * 1024; // 1 MB
+
+/// Account packet containing arbitrary user's account information.
+#[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
+pub struct AccountData {
+    destination: XorName,
+    authorised_getter: PublicKey, // deterministically created from passwords
+    data: Vec<u8>,
+    signature: Signature,
+}
+
+impl AccountData {
+    pub fn new(
+        destination: XorName,
+        authorised_getter: PublicKey,
+        data: Vec<u8>,
+        signature: Signature,
+    ) -> Result<Self> {
+        let account_data = Self {
+            destination,
+            authorised_getter,
+            data,
+            signature,
+        };
+        if account_data.size_is_valid() {
+            Ok(account_data)
+        } else {
+            Err(Error::ExceededSize)
+        }
+    }
+
+    pub fn size_is_valid(&self) -> bool {
+        self.data.len() <= MAX_ACCOUNT_DATA_BYTES
+    }
+
+    pub fn destination(&self) -> &XorName {
+        &self.destination
+    }
+
+    pub fn authorised_getter(&self) -> &PublicKey {
+        &self.authorised_getter
+    }
+
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    pub fn signature(&self) -> &Signature {
+        &self.signature
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AccountData, MAX_ACCOUNT_DATA_BYTES};
+    use crate::{ClientFullId, Error};
+    use rand;
+
+    #[test]
+    fn exceed_size_limit() {
+        let our_id = ClientFullId::new_ed25519(&mut rand::thread_rng());
+
+        let acc_data = vec![0; MAX_ACCOUNT_DATA_BYTES + 1];
+        let signature = our_id.sign(&acc_data);
+
+        let res = AccountData::new(
+            rand::random(),
+            *our_id.public_id().public_key(),
+            acc_data,
+            signature,
+        );
+
+        match res {
+            Err(Error::ExceededSize) => (),
+            Ok(_) => panic!("Unexpected success"),
+            Err(e) => panic!("Unexpected error: {:?}", e),
+        }
+    }
+
+    #[test]
+    fn valid() {
+        let our_id = ClientFullId::new_ed25519(&mut rand::thread_rng());
+
+        let acc_data = vec![1; 16];
+        let signature = our_id.sign(&acc_data);
+
+        let res = AccountData::new(
+            rand::random(),
+            *our_id.public_id().public_key(),
+            acc_data.clone(),
+            signature,
+        );
+
+        match res {
+            Ok(ad) => {
+                assert_eq!(ad.data(), acc_data.as_slice());
+            }
+            Err(e) => panic!("Unexpected error: {:?}", e),
+        }
+    }
+}

--- a/src/response.rs
+++ b/src/response.rs
@@ -10,7 +10,7 @@
 use crate::{
     AData, ADataIndices, ADataOwner, ADataPubPermissionSet, ADataPubPermissions,
     ADataUnpubPermissionSet, ADataUnpubPermissions, AppPermissions, Coins, Entries, IDataKind,
-    MDataPermissionSet, MDataValue, PublicKey, Result, SeqMutableData, UnseqMutableData,
+    MDataPermissionSet, MDataValue, PublicKey, Result, SeqMutableData, Signature, UnseqMutableData,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
@@ -80,7 +80,7 @@ pub enum Response {
     // ===== Account =====
     //
     /// Returns an encrypted account packet
-    GetAccount(Result<Vec<u8>>),
+    GetAccount(Result<(Vec<u8>, Signature)>),
     //
     /// Returns a success or failure status for a mutation operation.
     Mutation(Result<()>),


### PR DESCRIPTION
Instead of a single PutAccount RPC, we now have `CreateAccount`, `CreateAccountFor`, and `UpdateAccount`. `CreateAccountFor` is required for the case when a user asks a third party to create a new coin balance _and_ a new account for them.