### PR TITLE
fix/idata: make unpub idata owner field use safe-nd PublicKey

### DIFF
--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -51,6 +51,14 @@ impl PublicKey {
     pub fn decode_from_zbase32<I: Decodable>(encoded: I) -> Result<Self> {
         utils::decode(encoded)
     }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        match self {
+            PublicKey::Ed25519(key) => key.to_bytes().to_vec(),
+            PublicKey::Bls(key) => key.to_bytes().to_vec(),
+            PublicKey::BlsShare(key) => key.to_bytes().to_vec(),
+        }
+    }
 }
 
 #[allow(clippy::derive_hash_xor_eq)]


### PR DESCRIPTION
Hey guys, 

I am not sure of the `.to_bytes()` impl for `PublicKey` here. The default `to_bytes()` of ed25519 key gives a `[u8; 32]` whereas, thresholdcrypto keys' `to_bytes()` gives a `[u8,48]` . Hence I had to convert it to Vector for returning and again make it a slice at the consumption point. Can this be implemented a better way?(I am sure it can be :) )

Fixes https://github.com/maidsafe/safe_client_libs/issues/882