### PR TITLE
Update Container IDs

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,7 +1,7 @@
 FROM rust:latest
 
-RUN addgroup --gid 1000 maidsafe && \
-    adduser --uid 1000 --ingroup maidsafe --home /home/maidsafe --shell /bin/sh --disabled-password --gecos "" maidsafe && \
+RUN addgroup --gid 1001 maidsafe && \
+    adduser --uid 1001 --ingroup maidsafe --home /home/maidsafe --shell /bin/sh --disabled-password --gecos "" maidsafe && \
     # The parent container sets this to the 'staff' group, which causes problems
     # with reading code stored in Cargo's registry.
     chgrp -R maidsafe /usr/local
@@ -33,4 +33,4 @@ RUN rustup component add rustfmt clippy && \
     cargo clippy --verbose --release --all-targets && \
     cargo test --verbose --release && \
     find /target/release/ -maxdepth 1 -type f -exec rm '{}' \;
-ENTRYPOINT ["fixuid", "-q"]
+ENTRYPOINT ["fixuid"]


### PR DESCRIPTION
This synchronises the IDs with the IDs of the `jenkins` user on the build slave. This should hopefully reduce the Linux build time quite significantly, because it avoids having to change permissions for thousands of files (this is a classic problem with Docker - details [here](https://boxboat.com/2017/07/25/fixuid-change-docker-container-uid-gid/) if you're interested). The external disks used by machines on AWS are quite slow, so changing all the permissions can take 5 - 10 minutes sometimes.

Once this is merged I can regenerate the slave with the updated container.

Cheers,

Chris