### PR TITLE
feat/adata: add GetADataValue request/response types and get_value function for AData enum

### DIFF
--- a/src/append_only_data.rs
+++ b/src/append_only_data.rs
@@ -829,6 +829,15 @@ impl Data {
         }
     }
 
+    pub fn get(&self, key: &[u8]) -> Option<&Vec<u8>> {
+        match self {
+            Data::PubSeq(data) => data.get(key),
+            Data::PubUnseq(data) => data.get(key),
+            Data::UnpubSeq(data) => data.get(key),
+            Data::UnpubUnseq(data) => data.get(key),
+        }
+    }
+
     pub fn indices(&self) -> Result<Indices> {
         match self {
             Data::PubSeq(data) => indices!(data),

--- a/src/request.rs
+++ b/src/request.rs
@@ -101,6 +101,10 @@ pub enum Request {
         // range: (Index::FromStart(0), Index::FromStart(5))
         range: (ADataIndex, ADataIndex),
     },
+    GetADataValue {
+        address: ADataAddress,
+        key: Vec<u8>,
+    },
     /// Get current indices: data, owners, permissions.
     GetADataIndices(ADataAddress),
     /// Get an entry with the current index.
@@ -230,6 +234,7 @@ impl fmt::Debug for Request {
                 PutAData(_) => "Request::PutAData",
                 GetAData(_) => "Request::GetAData",
                 GetADataShell { .. } => "Request::GetADataShell",
+                GetADataValue { .. } => "Request::GetADataValue ",
                 DeleteAData(_) => "Request::DeleteAData",
                 GetADataRange { .. } => "Request::GetADataRange",
                 GetADataIndices(_) => "Request::GetADataIndices",

--- a/src/response.rs
+++ b/src/response.rs
@@ -45,6 +45,7 @@ pub enum Response {
     GetADataShell(Result<AData>),
     GetADataOwners(Result<ADataOwner>),
     GetADataRange(Result<ADataEntries>),
+    GetADataValue(Result<Vec<u8>>),
     GetADataIndices(Result<ADataIndices>),
     GetADataLastEntry(Result<(Vec<u8>, Vec<u8>)>),
     GetUnpubADataPermissionAtIndex(Result<ADataUnpubPermissions>),
@@ -114,6 +115,7 @@ impl fmt::Debug for Response {
                 write!(f, "Response::ListAuthKeysAndVersion({:?})", ErrorDebug(res))
             }
             GetAData(res) => write!(f, "Response::GetAData({:?})", ErrorDebug(res)),
+            GetADataValue(res) => write!(f, "Response::GetADataValue({:?})", ErrorDebug(res)),
             GetADataRange(res) => write!(f, "Response::GetADataRange({:?})", ErrorDebug(res)),
             GetADataIndices(res) => write!(f, "Response::GetADataIndices({:?})", ErrorDebug(res)),
             GetADataLastEntry(res) => {


### PR DESCRIPTION
Required for maidsafe/safe_client_libs#879