### PR TITLE
feat/mdata: add helper function for MData enum to fetch owner field

### DIFF
--- a/src/mutable_data.rs
+++ b/src/mutable_data.rs
@@ -759,6 +759,13 @@ impl Data {
             Data::Unseq(data) => data.check_permissions(request, requester),
         }
     }
+
+    pub fn owner(&self) -> PublicKey {
+        match self {
+            Data::Seq(data) => data.owners,
+            Data::Unseq(data) => data.owners,
+        }
+    }
 }
 
 impl From<SeqMutableData> for Data {


### PR DESCRIPTION
Required for maidsafe/safe_client_libs#885