### PR TITLE
derive Ord, PartialOrd and Hash for PublicKey and Signature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ version = "0.1.0"
 [dependencies]
 # Ensure bincode version is identical to that in SAFE Client Libs and SAFE Vault.
 bincode = "=1.1.4"
-ed25519-dalek = "~0.9.1"
+# ed25519-dalek = "~0.9.1"
+ed25519-dalek = { git = "https://github.com/madadam/ed25519-dalek.git", branch = "traits" }
 hex_fmt = "~0.3.0"
 multibase = "~0.6.0"
 rand = "~0.6.5"

--- a/src/identity/app.rs
+++ b/src/identity/app.rs
@@ -8,9 +8,7 @@
 // Software.
 
 use super::client::Keypair;
-use crate::{
-    utils, ClientFullId, ClientPublicId, Ed25519Digest, Error, PublicKey, Signature, XorName,
-};
+use crate::{utils, ClientFullId, ClientPublicId, Error, PublicKey, Signature, XorName};
 use multibase::Decodable;
 use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
@@ -54,7 +52,7 @@ impl FullId {
     /// Creates a detached signature of `data`.
     pub fn sign<T: AsRef<[u8]>>(&self, data: T) -> Signature {
         match &self.keypair {
-            Keypair::Ed25519(keys) => Signature::Ed25519(keys.sign::<Ed25519Digest>(data.as_ref())),
+            Keypair::Ed25519(keys) => Signature::Ed25519(keys.sign(data.as_ref())),
             Keypair::Bls(keys) => Signature::Bls(keys.secret.inner().sign(data)),
             Keypair::BlsShare(keys) => Signature::BlsShare(keys.secret.inner().sign(data)),
         }

--- a/src/identity/client.rs
+++ b/src/identity/client.rs
@@ -8,7 +8,7 @@
 // Software.
 
 use super::{BlsKeypair, BlsKeypairShare};
-use crate::{utils, Ed25519Digest, Error, PublicKey, Signature, XorName};
+use crate::{utils, Error, PublicKey, Signature, XorName};
 use ed25519_dalek::Keypair as Ed25519Keypair;
 use multibase::Decodable;
 use rand::{CryptoRng, Rng};
@@ -35,7 +35,7 @@ pub struct FullId {
 impl FullId {
     /// Constructs a `FullId` with a random Ed25519 keypair.
     pub fn new_ed25519<T: CryptoRng + Rng>(rng: &mut T) -> Self {
-        let ed25519_keypair = Ed25519Keypair::generate::<Ed25519Digest, _>(rng);
+        let ed25519_keypair = Ed25519Keypair::generate(rng);
         let public_key = PublicKey::Ed25519(ed25519_keypair.public);
         let public_id = PublicId {
             name: public_key.into(),
@@ -87,7 +87,7 @@ impl FullId {
     /// Creates a detached signature of `data`.
     pub fn sign<T: AsRef<[u8]>>(&self, data: T) -> Signature {
         match &self.keypair {
-            Keypair::Ed25519(keys) => Signature::Ed25519(keys.sign::<Ed25519Digest>(data.as_ref())),
+            Keypair::Ed25519(keys) => Signature::Ed25519(keys.sign(data.as_ref())),
             Keypair::Bls(keys) => Signature::Bls(keys.secret.inner().sign(data)),
             Keypair::BlsShare(keys) => Signature::BlsShare(keys.secret.inner().sign(data)),
         }

--- a/src/identity/node.rs
+++ b/src/identity/node.rs
@@ -8,7 +8,7 @@
 // Software.
 
 use super::BlsKeypairShare;
-use crate::{utils, Ed25519Digest, Error, PublicKey, Signature, XorName};
+use crate::{utils, Error, PublicKey, Signature, XorName};
 use ed25519_dalek::{Keypair as Ed25519Keypair, PublicKey as Ed25519PublicKey};
 use hex_fmt::HexFmt;
 use multibase::Decodable;
@@ -36,7 +36,7 @@ pub struct FullId {
 impl FullId {
     /// Constructs a `FullId` with a random Ed25519 keypair and no BLS keys.
     pub fn new<T: CryptoRng + Rng>(rng: &mut T) -> Self {
-        let ed25519 = Ed25519Keypair::generate::<Ed25519Digest, _>(rng);
+        let ed25519 = Ed25519Keypair::generate(rng);
         let name = PublicKey::Ed25519(ed25519.public).into();
         let public_id = PublicId {
             name,
@@ -52,7 +52,7 @@ impl FullId {
 
     /// Constructs a `FullId` whose name is in the interval [start, end] (both endpoints inclusive).
     pub fn within_range<T: CryptoRng + Rng>(start: &XorName, end: &XorName, rng: &mut T) -> Self {
-        let mut ed25519 = Ed25519Keypair::generate::<Ed25519Digest, _>(rng);
+        let mut ed25519 = Ed25519Keypair::generate(rng);
         loop {
             let name = PublicKey::Ed25519(ed25519.public).into();
             if name >= *start && name <= *end {
@@ -67,7 +67,7 @@ impl FullId {
                     public_id,
                 };
             }
-            ed25519 = Ed25519Keypair::generate::<Ed25519Digest, _>(rng);
+            ed25519 = Ed25519Keypair::generate(rng);
         }
     }
 
@@ -78,7 +78,7 @@ impl FullId {
 
     /// Creates a detached Ed25519 signature of `data`.
     pub fn sign_using_ed25519<T: AsRef<[u8]>>(&self, data: T) -> Signature {
-        Signature::Ed25519(self.ed25519.sign::<Ed25519Digest>(data.as_ref()))
+        Signature::Ed25519(self.ed25519.sign(data.as_ref()))
     }
 
     /// Creates a detached BLS signature share of `data` if the `self` holds a BLS keypair share.


### PR DESCRIPTION
Instead of implementing them. This is possible because ed25519-dalek::{PublicKey,Signature} implement those traits now.

Note: this uses [git dependency](https://github.com/madadam/ed25519-dalek.git) of ed25519-dalek for now until https://github.com/dalek-cryptography/ed25519-dalek/pull/93 is merged.   