### PR TITLE
Simplify adata and mdata implementations

### DIFF
--- a/src/append_only_data.rs
+++ b/src/append_only_data.rs
@@ -7,7 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use crate::{utils, Error, PublicKey, Result, Seq, Unseq, XorName};
+use crate::{utils, Error, PublicKey, Result, XorName};
 use multibase::Decodable;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
@@ -22,6 +22,14 @@ pub type PubUnseqAppendOnlyData = AppendOnlyData<PubPermissions, Unseq>;
 pub type UnpubSeqAppendOnlyData = AppendOnlyData<UnpubPermissions, Seq>;
 pub type UnpubUnseqAppendOnlyData = AppendOnlyData<UnpubPermissions, Unseq>;
 pub type Entries = Vec<Entry>;
+
+/// Marker for sequential data.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
+pub struct Seq;
+
+/// Marker for unsequential data.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
+pub struct Unseq;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
 pub enum User {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,8 +94,8 @@ pub use mutable_data::{
     SeqEntries as MDataSeqEntries, SeqEntryAction as MDataSeqEntryAction,
     SeqEntryActions as MDataSeqEntryActions, SeqMutableData, SeqValue as MDataSeqValue,
     UnseqEntries as MDataUnseqEntries, UnseqEntryAction as MDataUnseqEntryAction,
-    UnseqEntryActions as MDataUnseqEntryActions, UnseqMutableData, Value as MDataValue,
-    Values as MDataValues,
+    UnseqEntryActions as MDataUnseqEntryActions, UnseqMutableData, UnseqValue as MDataUnseqValue,
+    Value as MDataValue, Values as MDataValues,
 };
 pub use public_key::{PublicKey, Signature};
 pub use request::{LoginPacket, Request, MAX_LOGIN_PACKET_BYTES};
@@ -265,14 +265,6 @@ pub enum Challenge {
 /// Notification of a transaction.
 #[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Serialize, Deserialize, Debug)]
 pub struct Notification(pub Transaction);
-
-/// Marker for sequential data.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
-pub struct Seq;
-
-/// Marker for unsequential data.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
-pub struct Unseq;
 
 #[cfg(test)]
 mod test {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,9 +73,8 @@ pub use append_only_data::{
     Indices as ADataIndices, Kind as ADataKind, Owner as ADataOwner,
     Permissions as ADataPermissions, PubPermissionSet as ADataPubPermissionSet,
     PubPermissions as ADataPubPermissions, PubSeqAppendOnlyData, PubUnseqAppendOnlyData,
-    SeqAppendOnly, UnpubPermissionSet as ADataUnpubPermissionSet,
-    UnpubPermissions as ADataUnpubPermissions, UnpubSeqAppendOnlyData, UnpubUnseqAppendOnlyData,
-    UnseqAppendOnly, User as ADataUser,
+    UnpubPermissionSet as ADataUnpubPermissionSet, UnpubPermissions as ADataUnpubPermissions,
+    UnpubSeqAppendOnlyData, UnpubUnseqAppendOnlyData, User as ADataUser,
 };
 pub use coins::{Coins, MAX_COINS_VALUE};
 pub use errors::{EntryError, Error, Result};
@@ -266,6 +265,14 @@ pub enum Challenge {
 /// Notification of a transaction.
 #[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Serialize, Deserialize, Debug)]
 pub struct Notification(pub Transaction);
+
+/// Marker for sequential data.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
+pub struct Seq;
+
+/// Marker for unsequential data.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
+pub struct Unseq;
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
The prevous impl based on traits and macros was unnecessarily complex. This PR simplifies it using an approach similar to "policy-based design" known from C++.