### PR TITLE
chore/lib: update Challenge::Request

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,7 @@ impl Default for MessageId {
 #[allow(clippy::large_enum_variant)]
 #[derive(Serialize, Deserialize)]
 pub enum Challenge {
-    Request(Vec<u8>),
+    Request(PublicId, Vec<u8>),
     Response(PublicId, Signature),
 }
 


### PR DESCRIPTION
When a vault sends a `Challenge::Request` to a client/app it needs to include its `PublicId` in order to allow the client/app to make an association between that ID and the vault's `SocketAddr`.

