### PR TITLE
Publish to crates.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 stage('build & test') {
     parallel mock_linux: {
-        node('docker') {
+        node('safe_nd') {
             checkout(scm)
             sh("make test")
         }
@@ -17,4 +17,30 @@ stage('build & test') {
             sh("make test")
         }
     }
+}
+
+stage('deploy') {
+    node('safe_nd') {
+        checkout(scm)
+        if (env.BRANCH_NAME == "master") {
+            if (versionChangeCommit()) {
+                withCredentials([string(
+                    credentialsId: 'crates_io_token', variable: 'CRATES_IO_TOKEN')]) {
+                    sh("make publish")
+                }
+            }
+        } else {
+            echo("${env.BRANCH_NAME} does not match deployment branch. Nothing to do.")
+        }
+    }
+}
+
+def versionChangeCommit() {
+    shortCommitHash = sh(
+        returnStdout: true,
+        script: "git log -n 1 --pretty=format:'%h'").trim()
+    message = sh(
+        returnStdout: true,
+        script: "git log --format=%B -n 1 ${shortCommitHash}").trim()
+    return message.startsWith("Version change")
 }

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,14 @@ else
 	cargo fmt -- --check
 	cargo test --verbose --release
 endif
+
+publish:
+ifndef CRATES_IO_TOKEN
+	@echo "A login token for crates.io must be provided."
+	@exit 1
+endif
+	rm -rf artifacts
+	docker run --rm -v "${PWD}":/usr/src/safe-nd:Z \
+		-u ${USER_ID}:${GROUP_ID} \
+		maidsafe/safe-nd-build:build \
+		/bin/bash -c "cargo login ${CRATES_IO_TOKEN} && cargo package && cargo publish"

--- a/Makefile
+++ b/Makefile
@@ -8,17 +8,17 @@ UUID := $(shell uuidgen | sed 's/-//g')
 
 build-container:
 	rm -rf target/
-	docker rmi -f maidsafe/safe-nd-build:${SAFE_ND_VERSION}
-	docker build -f Dockerfile.build -t maidsafe/safe-nd-build:${SAFE_ND_VERSION} .
+	docker rmi -f maidsafe/safe-nd-build:build
+	docker build -f Dockerfile.build -t maidsafe/safe-nd-build:build .
 
 push-container:
-	docker push maidsafe/safe-nd-build:${SAFE_ND_VERSION}
+	docker push maidsafe/safe-nd-build:build
 
 test:
 ifeq ($(UNAME_S),Linux)
 	docker run --name "safe-nd-build-${UUID}" -v "${PWD}":/usr/src/safe-nd:Z \
 		-u ${USER_ID}:${GROUP_ID} \
-		maidsafe/safe-nd-build:${SAFE_ND_VERSION} \
+		maidsafe/safe-nd-build:build \
 		/bin/bash -c "cargo fmt -- --check --verbose && cargo clippy --verbose --release --all-targets && cargo test --verbose --release"
 	docker cp "safe-nd-build-${UUID}":/target .
 	docker rm "safe-nd-build-${UUID}"


### PR DESCRIPTION
Hi Nikita,

On a master and version change build, this will publish to crates.io. Since there is a restriction on crates.io that you can't delete any crates that are uploaded, I done the work for this using a sample library that we have.

Here are some links that show the process working:

* [These](https://crates.io/crates/jenkins_sample_lib) crates were published for the sample project.
* [Here](https://jenkins.maidsafe.net/blue/organizations/jenkins/pipeline-sandbox/detail/pipeline-sandbox/3/pipeline) is the build that produced version 0.0.3.
* [Here](https://github.com/maidsafe/jenkins_sample_lib/blob/master/Jenkinsfile) is the Jenkinsfile for the sample lib project. You can see that the code is the same (other than for retrieving build artifacts on the deploy stage, but we don't actually need that for a publish - you only need access to the source, which is why we don't retrieve any build artifacts yet for safe-nd).

But we can't truly test this until we have a case where we actually want to change the version. However, on the basis that it works for the other project, I'm confident the same mechanism will work here.

Cheers,

Chris 