### PR TITLE
Filter Commits for Deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,11 +36,9 @@ stage('deploy') {
 }
 
 def versionChangeCommit() {
-    // Gets the 2nd commit, because the first one will be a 'Merge pull request...'
-    // commit resulting from the merge to master.
     shortCommitHash = sh(
         returnStdout: true,
-        script: "git log -n 2 --pretty=format:'%h' | tail -n 1").trim()
+        script: "git log -n 1 --no-merges --pretty=format:'%h'").trim()
     message = sh(
         returnStdout: true,
         script: "git log --format=%B -n 1 ${shortCommitHash}").trim()


### PR DESCRIPTION
It turns out we can use the `--no-merges` option to remove the merge
related commits. This is a much nicer solution.