### PR TITLE
refactor/all: move functions to safe-nd

### DIFF
--- a/src/append_only_data.rs
+++ b/src/append_only_data.rs
@@ -57,7 +57,7 @@
 //! index while appending. For unsequenced AppendOnlyData the client does not have to pass the
 //! index.
 
-use crate::{utils, Error, PublicKey, Request, Result, XorName};
+use crate::{utils, Error, PublicKey, Result, XorName};
 use multibase::Decodable;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -1053,42 +1053,6 @@ impl Data {
             }
             Data::UnpubSeq(data) => check_perm!(data, requester, action),
             Data::UnpubUnseq(data) => check_perm!(data, requester, action),
-        }
-    }
-
-    /// Checks permissions for given `request` for the provided user.
-    ///
-    /// Returns:
-    /// See `check_permission` and `check_is_last_owner` for possible errors.
-    pub fn check_request_permissions(&self, request: &Request, requester: PublicKey) -> Result<()> {
-        match request {
-            Request::GetAData(..)
-            | Request::GetADataShell { .. }
-            | Request::GetADataValue { .. }
-            | Request::GetADataRange { .. }
-            | Request::GetADataIndices(..)
-            | Request::GetADataLastEntry(..)
-            | Request::GetADataPermissions { .. }
-            | Request::GetPubADataUserPermissions { .. }
-            | Request::GetUnpubADataUserPermissions { .. }
-            | Request::GetADataOwners { .. } => match *self {
-                Data::PubUnseq(_) | Data::PubSeq(_) => Ok(()),
-                Data::UnpubSeq(_) | Data::UnpubUnseq(_) => {
-                    self.check_permission(Action::Read, requester)
-                }
-            },
-            Request::AppendSeq { .. } | Request::AppendUnseq { .. } => {
-                self.check_permission(Action::Append, requester)
-            }
-            Request::AddPubADataPermissions { .. } | Request::AddUnpubADataPermissions { .. } => {
-                self.check_permission(Action::ManagePermissions, requester)
-            }
-            Request::SetADataOwner { .. } => self.check_is_last_owner(requester),
-            Request::DeleteAData(_) => match *self {
-                Data::PubSeq(_) | Data::PubUnseq(_) => Err(Error::InvalidOperation),
-                Data::UnpubSeq(_) | Data::UnpubUnseq(_) => self.check_is_last_owner(requester),
-            },
-            _ => Err(Error::InvalidOperation),
         }
     }
 

--- a/src/append_only_data.rs
+++ b/src/append_only_data.rs
@@ -57,7 +57,7 @@
 //! index while appending. For unsequenced AppendOnlyData the client does not have to pass the
 //! index.
 
-use crate::{utils, Error, PublicKey, Result, XorName};
+use crate::{utils, Error, PublicKey, Request, Result, XorName};
 use multibase::Decodable;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -1053,6 +1053,42 @@ impl Data {
             }
             Data::UnpubSeq(data) => check_perm!(data, requester, action),
             Data::UnpubUnseq(data) => check_perm!(data, requester, action),
+        }
+    }
+
+    /// Checks permissions for given `request` for the provided user.
+    ///
+    /// Returns:
+    /// See `check_permission` and `check_is_last_owner` for possible errors.
+    pub fn check_request_permissions(&self, request: &Request, requester: PublicKey) -> Result<()> {
+        match request {
+            Request::GetAData(..)
+            | Request::GetADataShell { .. }
+            | Request::GetADataValue { .. }
+            | Request::GetADataRange { .. }
+            | Request::GetADataIndices(..)
+            | Request::GetADataLastEntry(..)
+            | Request::GetADataPermissions { .. }
+            | Request::GetPubADataUserPermissions { .. }
+            | Request::GetUnpubADataUserPermissions { .. }
+            | Request::GetADataOwners { .. } => match *self {
+                Data::PubUnseq(_) | Data::PubSeq(_) => Ok(()),
+                Data::UnpubSeq(_) | Data::UnpubUnseq(_) => {
+                    self.check_permission(Action::Read, requester)
+                }
+            },
+            Request::AppendSeq { .. } | Request::AppendUnseq { .. } => {
+                self.check_permission(Action::Append, requester)
+            }
+            Request::AddPubADataPermissions { .. } | Request::AddUnpubADataPermissions { .. } => {
+                self.check_permission(Action::ManagePermissions, requester)
+            }
+            Request::SetADataOwner { .. } => self.check_is_last_owner(requester),
+            Request::DeleteAData(_) => match *self {
+                Data::PubSeq(_) | Data::PubUnseq(_) => Err(Error::InvalidOperation),
+                Data::UnpubSeq(_) | Data::UnpubUnseq(_) => self.check_is_last_owner(requester),
+            },
+            _ => Err(Error::InvalidOperation),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ pub use mutable_data::{
     Values as MDataValues,
 };
 pub use public_key::{PublicKey, Signature};
-pub use request::{LoginPacket, Request, MAX_LOGIN_PACKET_BYTES};
+pub use request::{LoginPacket, Request, RequestType, MAX_LOGIN_PACKET_BYTES};
 pub use response::{Response, TryFromError};
 pub use sha3::Sha3_512 as Ed25519Digest;
 pub use transaction::{Transaction, TransactionId};

--- a/src/mutable_data.rs
+++ b/src/mutable_data.rs
@@ -27,7 +27,7 @@
 //! does not have to pass version numbers for keys, but it still must pass the next version number
 //! while modifying the MutableData shell.
 
-use crate::{utils, EntryError, Error, PublicKey, Request, Result, XorName};
+use crate::{utils, EntryError, Error, PublicKey, Result, XorName};
 use hex_fmt::HexFmt;
 use multibase::Decodable;
 use serde::{Deserialize, Serialize};
@@ -872,36 +872,6 @@ impl Data {
         match self {
             Data::Seq(data) => data.check_permissions(action, requester),
             Data::Unseq(data) => data.check_permissions(action, requester),
-        }
-    }
-
-    /// Checks permissions for given `request` for the provided user.
-    ///
-    /// Returns:
-    /// See `check_permissions` and `check_is_last_owner` for possible errors.
-    pub fn check_request_permissions(&self, request: &Request, requester: PublicKey) -> Result<()> {
-        match request {
-            Request::GetMData { .. }
-            | Request::GetMDataShell { .. }
-            | Request::GetMDataVersion { .. }
-            | Request::ListMDataKeys { .. }
-            | Request::ListMDataEntries { .. }
-            | Request::ListMDataValues { .. }
-            | Request::GetMDataValue { .. }
-            | Request::ListMDataPermissions { .. }
-            | Request::ListMDataUserPermissions { .. } => {
-                self.check_permissions(Action::Read, requester)
-            }
-
-            Request::SetMDataUserPermissions { .. } | Request::DelMDataUserPermissions { .. } => {
-                self.check_permissions(Action::ManagePermissions, requester)
-            }
-
-            Request::MutateMDataEntries { .. } => Ok(()),
-
-            Request::DeleteMData { .. } => self.check_is_owner(requester),
-
-            _ => Err(Error::InvalidOperation),
         }
     }
 


### PR DESCRIPTION
Move the following functions from SCL:
1. `request_is_get` (renamed to `Request::get_type`)
2. ~`check_is_owner_adata`~ (already existed as `AData::check_is_last_owner`)
3. `check_perms_adata`
4. `check_perms_mdata`