### PR TITLE
refactor/permission: granularize AppPermissions struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,10 @@ impl From<AData> for Data {
 pub struct AppPermissions {
     /// Whether this app has permissions to transfer coins.
     pub transfer_coins: bool,
+    /// Whether this app has permissions to perform mutations.
+    pub perform_mutations: bool,
+    /// Whether this app has permissions to read the coin balance.
+    pub get_balance: bool,
 }
 
 /// Constant byte length of `XorName`.


### PR DESCRIPTION
Required for maidsafe/safe_client_libs#989 and maidsafe/safe_client_libs#990
- Adds `allow_mutations` and `get_balance` booleans to `AppPermissions`