### PR TITLE
fix/get: add missing api to AppendOnlyData trait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ before_script:
     fi
   - rustup component add rustfmt clippy
 script:
-  - cargo fmt -- --check
-  - cargo clippy --verbose --release --all-targets
-  - cargo test --verbose --release
+  - set -x;
+    cargo fmt -- --check &&
+    cargo clippy --verbose --release --all-targets &&
+    cargo test --verbose --release
 before_cache:
   - cargo prune

--- a/src/append_only_data.rs
+++ b/src/append_only_data.rs
@@ -1370,81 +1370,42 @@ mod tests {
 
     #[test]
     fn get_entry() {
-        // pub, unseq
-        let mut data = PubUnseqAppendOnlyData::new(rand::random(), 10);
+        let name: XorName = rand::random();
+        let tag = 10;
+
+        let mut pub_seq = PubSeqAppendOnlyData::new(name, tag);
+        let mut unpub_seq = UnpubSeqAppendOnlyData::new(name, tag);
+        let mut pub_unseq = PubUnseqAppendOnlyData::new(name, tag);
+        let mut unpub_unseq = UnpubUnseqAppendOnlyData::new(name, tag);
+
         let entries = vec![
             Entry::new(b"key0".to_vec(), b"value0".to_vec()),
             Entry::new(b"key1".to_vec(), b"value1".to_vec()),
         ];
-        unwrap!(data.append(entries));
-        let data = Data::from(data);
 
-        assert_eq!(
-            data.entry(Index::FromStart(0)),
-            Some(&Entry::new(b"key0".to_vec(), b"value0".to_vec()))
-        );
-        assert_eq!(
-            data.entry(Index::FromStart(1)),
-            Some(&Entry::new(b"key1".to_vec(), b"value1".to_vec()))
-        );
-        assert_eq!(data.entry(2), None);
+        unwrap!(pub_seq.append(entries.clone(), 0));
+        unwrap!(unpub_seq.append(entries.clone(), 0));
+        unwrap!(pub_unseq.append(entries.clone()));
+        unwrap!(unpub_unseq.append(entries.clone()));
 
-        // pub, seq
-        let mut data = PubSeqAppendOnlyData::new(rand::random(), 10);
-        let entries = vec![
-            Entry::new(b"key0".to_vec(), b"value0".to_vec()),
-            Entry::new(b"key1".to_vec(), b"value1".to_vec()),
+        let data_vec: Vec<Data> = vec![
+            pub_seq.into(),
+            unpub_seq.into(),
+            pub_unseq.into(),
+            unpub_unseq.into(),
         ];
-        unwrap!(data.append(entries, 0));
-        let data = Data::from(data);
 
-        assert_eq!(
-            data.entry(Index::FromStart(0)),
-            Some(&Entry::new(b"key0".to_vec(), b"value0".to_vec()))
-        );
-        assert_eq!(
-            data.entry(Index::FromStart(1)),
-            Some(&Entry::new(b"key1".to_vec(), b"value1".to_vec()))
-        );
-        assert_eq!(data.entry(2), None);
-
-        // unpub, unseq
-        let mut data = UnpubUnseqAppendOnlyData::new(rand::random(), 10);
-        let entries = vec![
-            Entry::new(b"key0".to_vec(), b"value0".to_vec()),
-            Entry::new(b"key1".to_vec(), b"value1".to_vec()),
-        ];
-        unwrap!(data.append(entries));
-        let data = Data::from(data);
-
-        assert_eq!(
-            data.entry(Index::FromStart(0)),
-            Some(&Entry::new(b"key0".to_vec(), b"value0".to_vec()))
-        );
-        assert_eq!(
-            data.entry(Index::FromStart(1)),
-            Some(&Entry::new(b"key1".to_vec(), b"value1".to_vec()))
-        );
-        assert_eq!(data.entry(2), None);
-
-        // unpub, seq
-        let mut data = UnpubSeqAppendOnlyData::new(rand::random(), 10);
-        let entries = vec![
-            Entry::new(b"key0".to_vec(), b"value0".to_vec()),
-            Entry::new(b"key1".to_vec(), b"value1".to_vec()),
-        ];
-        unwrap!(data.append(entries, 0));
-        let data = Data::from(data);
-
-        assert_eq!(
-            data.entry(Index::FromStart(0)),
-            Some(&Entry::new(b"key0".to_vec(), b"value0".to_vec()))
-        );
-        assert_eq!(
-            data.entry(Index::FromStart(1)),
-            Some(&Entry::new(b"key1".to_vec(), b"value1".to_vec()))
-        );
-        assert_eq!(data.entry(2), None);
+        for data in data_vec {
+            assert_eq!(
+                data.entry(Index::FromStart(0)),
+                Some(&Entry::new(b"key0".to_vec(), b"value0".to_vec()))
+            );
+            assert_eq!(
+                data.entry(Index::FromStart(1)),
+                Some(&Entry::new(b"key1".to_vec(), b"value1".to_vec()))
+            );
+            assert_eq!(data.entry(2), None);
+        }
     }
 
     #[test]

--- a/src/append_only_data.rs
+++ b/src/append_only_data.rs
@@ -1396,14 +1396,8 @@ mod tests {
         ];
 
         for data in data_vec {
-            assert_eq!(
-                data.entry(Index::FromStart(0)),
-                Some(&entries.clone()[0])
-            );
-            assert_eq!(
-                data.entry(Index::FromStart(1)),
-                Some(&entries.clone()[1])
-            );
+            assert_eq!(data.entry(Index::FromStart(0)), Some(&entries[0]));
+            assert_eq!(data.entry(Index::FromStart(1)), Some(&entries[1]));
             assert_eq!(data.entry(2), None);
         }
     }

--- a/src/append_only_data.rs
+++ b/src/append_only_data.rs
@@ -1398,11 +1398,11 @@ mod tests {
         for data in data_vec {
             assert_eq!(
                 data.entry(Index::FromStart(0)),
-                Some(&Entry::new(b"key0".to_vec(), b"value0".to_vec()))
+                Some(&entries.clone()[0])
             );
             assert_eq!(
                 data.entry(Index::FromStart(1)),
-                Some(&Entry::new(b"key1".to_vec(), b"value1".to_vec()))
+                Some(&entries.clone()[1])
             );
             assert_eq!(data.entry(2), None);
         }

--- a/src/append_only_data.rs
+++ b/src/append_only_data.rs
@@ -1367,7 +1367,7 @@ mod tests {
     use super::*;
     use threshold_crypto::SecretKey;
     use unwrap::{unwrap, unwrap_err};
-    
+
     #[test]
     fn get_entry() {
         // pub, unseq
@@ -1429,7 +1429,7 @@ mod tests {
 
         // unpub, seq
         let mut data = UnpubSeqAppendOnlyData::new(rand::random(), 10);
-                let entries = vec![
+        let entries = vec![
             Entry::new(b"key0".to_vec(), b"value0".to_vec()),
             Entry::new(b"key1".to_vec(), b"value1".to_vec()),
         ];


### PR DESCRIPTION
Getting Entry by index is missing, but exists for Owner and Permissions.
REFERENCE: #119