### PR TITLE
Update version to 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # safe-nd - Change Log
 
+## [0.6.1]
+- Implement `From` trait for `id::client::FullId` to allow conversion from supported key types.
+
 ## [0.6.0]
 
 - Change CI to GitHub Actions.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR BSD-3-Clause"
 name = "safe-nd"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe-nd"
-version = "0.6.0"
+version = "0.6.1"
 
 [dependencies]
 # Ensure bincode version is identical to that in SAFE Client Libs and SAFE Vault.


### PR DESCRIPTION
- A new version of safe-nd from the master branch, without the changes
in commit 2ff4165. This commit updates the version and the changelog.