### PR TITLE
chore/ci: add publish test build and caching

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,6 +13,8 @@ on:
       - master
 
 env:
+  # Run all cargo commands with --verbose.
+  CARGO_TERM_VERBOSE: true
   RUST_BACKTRACE: 1
 
 jobs:
@@ -24,16 +26,36 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v1
-      # TODO: Measure if any speedup from caching (no Cargo.lock, so always reuse cache)
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+      # Generate Cargo.lock, needed for the cache.
+      - uses: actions-rs/cargo@v1
+        with:
+          command: update
+      # Cache.
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+      # Make sure the code builds.
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --verbose --release
+          args: --release
 
   publish:
     name: Publish
@@ -41,17 +63,18 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
       # Is this a version change commit?
       - shell: bash
         id: commit_message
         run: |
           commit_message=$(git log --format=%B -n 1 ${{ github.sha }})
           echo "::set-output name=commit_message::$commit_message"
+      - uses: actions-rs/toolchain@v1
+        if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
       - uses: actions-rs/cargo@v1
         if: startsWith(steps.commit_message.outputs.commit_message, 'Version change')
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,10 @@ name: PR
 on: pull_request
 
 env:
+  # Run all cargo commands with --verbose.
+  CARGO_TERM_VERBOSE: true
   RUST_BACKTRACE: 1
+  # Deny all compiler warnings.
   RUSTFLAGS: "-D warnings"
 
 jobs:
@@ -29,7 +32,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --verbose --release --all-targets
+          args: --release --all-targets
 
   test:
     name: Test
@@ -48,4 +51,20 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --release
+          args: --release
+
+  # Test publish using --dry-run.
+  test-publish:
+    name: Test Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --dry-run


### PR DESCRIPTION
This PR enables caching in GitHub Actions.

I'm happy to report that, while builds are slightly slower if there is no matching cache, they are significantly faster when the cache is available.

[Control build without cache:](https://github.com/m-cat/safe-nd/runs/346206448)

|Ubuntu|Windows|macOS|
|---|---|---|
|145s|206s|123s|

[First build with caching (no cache available):](https://github.com/m-cat/safe-nd/runs/346277957)

|Ubuntu|Windows|macOS|
|---|---|---|
|168s|211s|127s|
|115.8%|102.4%|103.3%|

[Second build with caching (cache available):](https://github.com/m-cat/safe-nd/runs/346522339)

|Ubuntu|Windows|macOS|
|---|---|---|
|55s|92s|48s|
|37.9%|44.6%|39.0%|