### PR TITLE
Version change to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # safe-nd - Change Log
 
+## [0.7.0]
+
+- Change the Client<->Node handshake protocol: it replaces a one-purpose `Challenge` enum with a more extensive pair of enums, `HandshakeRequest` and `HandshakeResponse`.
+- Fix pedantic clippy errors.
+
 ## [0.6.1]
 - Implement `From` trait for `id::client::FullId` to allow conversion from supported key types.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR BSD-3-Clause"
 name = "safe-nd"
 readme = "README.md"
 repository = "https://github.com/maidsafe/safe-nd"
-version = "0.6.1"
+version = "0.7.0"
 
 [dependencies]
 # Ensure bincode version is identical to that in SAFE Client Libs and SAFE Vault.


### PR DESCRIPTION
Change the Client<->Node handshake protocol: it replaces a one-purpose `Challenge` enum with a more extensive pair of enums, `HandshakeRequest` and `HandshakeResponse`.