### PR TITLE
Refactor Permissions, Step 2.1: Add access_control

### DIFF
--- a/src/authorization/access_control.rs
+++ b/src/authorization/access_control.rs
@@ -1,0 +1,209 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+use crate::shared_types::User;
+use crate::PublicKey;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::{collections::BTreeMap, hash::Hash};
+
+/// ===========================================================
+///  Access control of data type instances and their content.
+/// ===========================================================
+
+/// The type of access to the native data structures.
+#[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub enum AccessType {
+    /// Read data, owners and permissions.
+    Read,
+    /// Append new values.
+    Append,
+    /// Insert new values.
+    Insert,
+    /// Soft-update existing values.
+    Update,
+    /// Soft-delete existing values.
+    Delete,
+    /// Hard-update existing values.
+    HardUpdate,
+    /// Hard-delete existing values.
+    HardDelete,
+    /// Modify permissions for other users.
+    ModifyPermissions,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash, Debug)]
+pub enum AccessList {
+    Public(PublicAccessList),
+    Private(PrivateAccessList),
+}
+
+impl From<PrivateAccessList> for AccessList {
+    fn from(list: PrivateAccessList) -> Self {
+        AccessList::Private(list)
+    }
+}
+
+impl From<PublicAccessList> for AccessList {
+    fn from(list: PublicAccessList) -> Self {
+        AccessList::Public(list)
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash, Debug)]
+pub enum UserAccess {
+    Public(PublicUserAccess),
+    Private(PrivateUserAccess),
+}
+
+impl From<PrivateUserAccess> for UserAccess {
+    fn from(access: PrivateUserAccess) -> Self {
+        UserAccess::Private(access)
+    }
+}
+
+impl From<PublicUserAccess> for UserAccess {
+    fn from(access: PublicUserAccess) -> Self {
+        UserAccess::Public(access)
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash, Debug)]
+pub struct PrivateUserAccess {
+    status: BTreeMap<AccessType, bool>,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash, Debug)]
+pub struct PublicUserAccess {
+    status: BTreeMap<AccessType, bool>,
+}
+
+impl PrivateUserAccess {
+    pub fn new(status: BTreeMap<AccessType, bool>) -> Self {
+        PrivateUserAccess { status }
+    }
+
+    pub fn set(&mut self, status: BTreeMap<AccessType, bool>) {
+        self.status = status;
+    }
+
+    pub fn is_allowed(self, access: &AccessType) -> bool {
+        match self.status.get(access) {
+            Some(true) => true,
+            _ => false,
+        }
+    }
+}
+
+impl PublicUserAccess {
+    pub fn new(status: BTreeMap<AccessType, bool>) -> Self {
+        PublicUserAccess { status }
+    }
+
+    pub fn set(&mut self, status: BTreeMap<AccessType, bool>) {
+        self.status = status; // todo: filter out Queries
+    }
+
+    /// Returns `Some(true)` if `access` is allowed and `Some(false)` if it's not.
+    /// `None` means that `User::Anyone` permissions apply.
+    pub fn is_allowed(self, access: &AccessType) -> Option<bool> {
+        match access {
+            AccessType::Read => Some(true), // It's Public data, so it's always allowed to read it.
+            _ => match self.status.get(access) {
+                Some(true) => Some(true),
+                Some(false) => Some(false),
+                None => None,
+            },
+        }
+    }
+}
+
+pub trait AccessListTrait: Clone + Eq + Ord + Hash + Serialize + DeserializeOwned {
+    fn is_allowed(&self, user: &PublicKey, access: &AccessType) -> bool;
+    fn expected_data_version(&self) -> u64;
+    fn expected_owners_version(&self) -> u64;
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash, Debug)]
+pub struct PrivateAccessList {
+    pub access_list: BTreeMap<PublicKey, PrivateUserAccess>,
+    /// The expected index of the data at the time this grant status change is to become valid.
+    pub expected_data_version: u64,
+    /// The expected index of the owners at the time this grant status is to become valid.
+    pub expected_owners_version: u64,
+}
+
+impl PrivateAccessList {
+    pub fn access_list(&self) -> &BTreeMap<PublicKey, PrivateUserAccess> {
+        &self.access_list
+    }
+}
+
+impl AccessListTrait for PrivateAccessList {
+    fn is_allowed(&self, user: &PublicKey, access: &AccessType) -> bool {
+        match self.access_list.get(user) {
+            Some(access_status) => access_status.clone().is_allowed(access),
+            None => false,
+        }
+    }
+
+    fn expected_data_version(&self) -> u64 {
+        self.expected_data_version
+    }
+
+    fn expected_owners_version(&self) -> u64 {
+        self.expected_owners_version
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash, Debug)]
+pub struct PublicAccessList {
+    pub access_list: BTreeMap<User, PublicUserAccess>,
+    /// The expected index of the data at the time this grant status change is to become valid.
+    pub expected_data_version: u64,
+    /// The expected index of the owners at the time this grant status change is to become valid.
+    pub expected_owners_version: u64,
+}
+
+impl PublicAccessList {
+    fn is_allowed_(&self, user: &User, access: &AccessType) -> Option<bool> {
+        match self.access_list.get(user) {
+            Some(status) => match status.clone().is_allowed(access) {
+                Some(true) => Some(true),
+                Some(false) => Some(false),
+                None => None,
+            },
+            _ => None,
+        }
+    }
+
+    pub fn access_list(&self) -> &BTreeMap<User, PublicUserAccess> {
+        &self.access_list
+    }
+}
+
+impl AccessListTrait for PublicAccessList {
+    fn is_allowed(&self, user: &PublicKey, access: &AccessType) -> bool {
+        match self.is_allowed_(&User::Specific(*user), access) {
+            Some(true) => true,
+            Some(false) => false,
+            None => match self.is_allowed_(&User::Anyone, access) {
+                Some(true) => true,
+                _ => false,
+            },
+        }
+    }
+
+    fn expected_data_version(&self) -> u64 {
+        self.expected_data_version
+    }
+
+    fn expected_owners_version(&self) -> u64 {
+        self.expected_owners_version
+    }
+}

--- a/src/authorization/mod.rs
+++ b/src/authorization/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+pub mod access_control;
+mod tests;
+pub use access_control::{
+    AccessList, AccessListTrait, AccessType, PrivateAccessList, PrivateUserAccess,
+    PublicAccessList, PublicUserAccess, UserAccess,
+};

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -1,0 +1,213 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+use crate::{utils, PublicKey, Result, XorName};
+use multibase::Decodable;
+use serde::{Deserialize, Serialize};
+use std::ops::Range;
+
+pub type Key = Vec<u8>;
+pub type Value = Vec<u8>;
+pub type KvPair = (Key, Value);
+pub type Values = Vec<Value>;
+pub type Keys = Vec<Key>;
+
+/// Marker for sentried data.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
+pub struct Sentried;
+
+/// Marker for non-sentried data.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
+pub struct NonSentried;
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
+pub enum User {
+    Anyone,
+    Specific(PublicKey),
+}
+
+#[derive(Copy, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum Version {
+    FromStart(u64), // Absolute index
+    FromEnd(u64),   // Relative Version - start counting from the end
+}
+
+impl From<u64> for Version {
+    fn from(version: u64) -> Self {
+        Version::FromStart(version)
+    }
+}
+
+// Set of data, owners, permissions versions.
+#[derive(Copy, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ExpectedVersions {
+    expected_data_version: u64,
+    expected_owners_version: u64,
+    expected_access_list_version: u64,
+}
+
+impl ExpectedVersions {
+    pub fn new(
+        expected_data_version: u64,
+        expected_owners_version: u64,
+        expected_access_list_version: u64,
+    ) -> Self {
+        ExpectedVersions {
+            expected_data_version,
+            expected_owners_version,
+            expected_access_list_version,
+        }
+    }
+
+    pub fn expected_data_version(&self) -> u64 {
+        self.expected_data_version
+    }
+
+    pub fn expected_owners_version(&self) -> u64 {
+        self.expected_owners_version
+    }
+
+    pub fn expected_access_list_version(&self) -> u64 {
+        self.expected_access_list_version
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
+pub struct Owner {
+    pub public_key: PublicKey,
+    /// The expected Version of the data at the time this ownership change is to become valid.
+    pub expected_data_version: u64,
+    /// The expected Version of the permissions at the time this ownership change is to become valid.
+    pub expected_access_list_version: u64,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
+pub enum Kind {
+    PublicSentried,
+    Public,
+    PrivateSentried,
+    Private,
+}
+
+impl Kind {
+    pub fn is_public(self) -> bool {
+        self == Kind::PublicSentried || self == Kind::Public
+    }
+
+    pub fn is_private(self) -> bool {
+        !self.is_public()
+    }
+
+    pub fn is_sentried(self) -> bool {
+        self == Kind::PublicSentried || self == Kind::PrivateSentried
+    }
+
+    /// Creates `Kind` from `public` and `sentried` flags.
+    pub fn from_flags(public: bool, sentried: bool) -> Self {
+        match (public, sentried) {
+            (true, true) => Kind::PublicSentried,
+            (true, false) => Kind::Public,
+            (false, true) => Kind::PrivateSentried,
+            (false, false) => Kind::Private,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
+pub enum DataAddress {
+    Map(Address),
+    Sequence(Address),
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
+pub enum Address {
+    PublicSentried { name: XorName, tag: u64 },
+    Public { name: XorName, tag: u64 },
+    PrivateSentried { name: XorName, tag: u64 },
+    Private { name: XorName, tag: u64 },
+}
+
+impl Address {
+    pub fn from_kind(kind: Kind, name: XorName, tag: u64) -> Self {
+        match kind {
+            Kind::PublicSentried => Address::PublicSentried { name, tag },
+            Kind::Public => Address::Public { name, tag },
+            Kind::PrivateSentried => Address::PrivateSentried { name, tag },
+            Kind::Private => Address::Private { name, tag },
+        }
+    }
+
+    pub fn kind(&self) -> Kind {
+        match self {
+            Address::PublicSentried { .. } => Kind::PublicSentried,
+            Address::Public { .. } => Kind::Public,
+            Address::PrivateSentried { .. } => Kind::PrivateSentried,
+            Address::Private { .. } => Kind::Private,
+        }
+    }
+
+    pub fn name(&self) -> &XorName {
+        match self {
+            Address::PublicSentried { ref name, .. }
+            | Address::Public { ref name, .. }
+            | Address::PrivateSentried { ref name, .. }
+            | Address::Private { ref name, .. } => name,
+        }
+    }
+
+    pub fn tag(&self) -> u64 {
+        match self {
+            Address::PublicSentried { tag, .. }
+            | Address::Public { tag, .. }
+            | Address::PrivateSentried { tag, .. }
+            | Address::Private { tag, .. } => *tag,
+        }
+    }
+
+    pub fn is_public(&self) -> bool {
+        self.kind().is_public()
+    }
+
+    pub fn is_private(&self) -> bool {
+        self.kind().is_private()
+    }
+
+    pub fn is_sentried(&self) -> bool {
+        self.kind().is_sentried()
+    }
+
+    /// Returns the Address serialised and encoded in z-base-32.
+    pub fn encode_to_zbase32(&self) -> String {
+        utils::encode(&self)
+    }
+
+    /// Create from z-base-32 encoded string.
+    pub fn decode_from_zbase32<I: Decodable>(encoded: I) -> Result<Self> {
+        utils::decode(encoded)
+    }
+}
+
+pub fn to_absolute_version(version: Version, count: usize) -> Option<usize> {
+    match version {
+        Version::FromStart(version) if version as usize <= count => Some(version as usize),
+        Version::FromStart(_) => None,
+        Version::FromEnd(version) => count.checked_sub(version as usize),
+    }
+}
+
+pub fn to_absolute_range(start: Version, end: Version, count: usize) -> Option<Range<usize>> {
+    let start = to_absolute_version(start, count)?;
+    let end = to_absolute_version(end, count)?;
+
+    if start <= end {
+        Some(start..end)
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
Draft for discussions with partial implementations. **Not to be merged.**

**NB:** The draft is primarily intended to focus on discussion about the **concept changes** and **idiomatic rust**. Small things, like typos or smallish wording changes in docs, indentation and similar trivialities can be addressed in the real PR (if they are still present). 
Anything off that is already present in current code base (i.e. not part of this change) could perhaps better go into a proper issue - as to keep discussion focused around the actual changes.

For the full implementation, see https://github.com/oetyng/safe-nd/tree/datatypes-refinement-demo

- Adds `shared_types.rs`.
- Adds `access_control.rs` in `authorization` mod.
- Identifies existing permissions concept as access list.

Step **2.2** adds tests using the refactored data types.