### PR TITLE
Refactor AppendOnlyData, step 3.1: Add Sequence

### DIFF
--- a/src/authorization/access_control.rs
+++ b/src/authorization/access_control.rs
@@ -94,8 +94,8 @@ impl PrivateUserAccess {
         self.status = status;
     }
 
-    pub fn is_allowed(self, access: &AccessType) -> bool {
-        match self.status.get(access) {
+    pub fn is_allowed(&self, access: AccessType) -> bool {
+        match self.status.get(&access) {
             Some(true) => true,
             _ => false,
         }
@@ -113,10 +113,10 @@ impl PublicUserAccess {
 
     /// Returns `Some(true)` if `access` is allowed and `Some(false)` if it's not.
     /// `None` means that `User::Anyone` permissions apply.
-    pub fn is_allowed(self, access: &AccessType) -> Option<bool> {
+    pub fn is_allowed(&self, access: AccessType) -> Option<bool> {
         match access {
             AccessType::Read => Some(true), // It's Public data, so it's always allowed to read it.
-            _ => match self.status.get(access) {
+            _ => match self.status.get(&access) {
                 Some(true) => Some(true),
                 Some(false) => Some(false),
                 None => None,
@@ -126,7 +126,7 @@ impl PublicUserAccess {
 }
 
 pub trait AccessListTrait: Clone + Eq + Ord + Hash + Serialize + DeserializeOwned {
-    fn is_allowed(&self, user: &PublicKey, access: &AccessType) -> bool;
+    fn is_allowed(&self, user: &PublicKey, access: AccessType) -> bool;
     fn expected_data_version(&self) -> u64;
     fn expected_owners_version(&self) -> u64;
 }
@@ -147,7 +147,7 @@ impl PrivateAccessList {
 }
 
 impl AccessListTrait for PrivateAccessList {
-    fn is_allowed(&self, user: &PublicKey, access: &AccessType) -> bool {
+    fn is_allowed(&self, user: &PublicKey, access: AccessType) -> bool {
         match self.access_list.get(user) {
             Some(access_status) => access_status.clone().is_allowed(access),
             None => false,
@@ -173,7 +173,7 @@ pub struct PublicAccessList {
 }
 
 impl PublicAccessList {
-    fn is_allowed_(&self, user: &User, access: &AccessType) -> Option<bool> {
+    fn is_allowed_(&self, user: &User, access: AccessType) -> Option<bool> {
         match self.access_list.get(user) {
             Some(status) => match status.clone().is_allowed(access) {
                 Some(true) => Some(true),
@@ -190,7 +190,7 @@ impl PublicAccessList {
 }
 
 impl AccessListTrait for PublicAccessList {
-    fn is_allowed(&self, user: &PublicKey, access: &AccessType) -> bool {
+    fn is_allowed(&self, user: &PublicKey, access: AccessType) -> bool {
         match self.is_allowed_(&User::Specific(*user), access) {
             Some(true) => true,
             Some(false) => false,

--- a/src/authorization/access_control.rs
+++ b/src/authorization/access_control.rs
@@ -7,6 +7,8 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
+#![allow(dead_code)] // for the draft PR only
+
 use crate::shared_types::User;
 use crate::PublicKey;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};

--- a/src/authorization/access_control.rs
+++ b/src/authorization/access_control.rs
@@ -1,0 +1,209 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+use crate::shared_types::User;
+use crate::PublicKey;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::{collections::BTreeMap, hash::Hash};
+
+/// ===========================================================
+///  Access control of data type instances and their content.
+/// ===========================================================
+
+/// The type of access to the native data structures.
+#[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub enum AccessType {
+    /// Read data, owners and permissions.
+    Read,
+    /// Append new values.
+    Append,
+    /// Insert new values.
+    Insert,
+    /// Soft-update existing values.
+    Update,
+    /// Soft-delete existing values.
+    Delete,
+    /// Hard-update existing values.
+    HardUpdate,
+    /// Hard-delete existing values.
+    HardDelete,
+    /// Modify permissions for other users.
+    ModifyPermissions,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash, Debug)]
+pub enum AccessList {
+    Public(PublicAccessList),
+    Private(PrivateAccessList),
+}
+
+impl From<PrivateAccessList> for AccessList {
+    fn from(list: PrivateAccessList) -> Self {
+        AccessList::Private(list)
+    }
+}
+
+impl From<PublicAccessList> for AccessList {
+    fn from(list: PublicAccessList) -> Self {
+        AccessList::Public(list)
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash, Debug)]
+pub enum UserAccess {
+    Public(PublicUserAccess),
+    Private(PrivateUserAccess),
+}
+
+impl From<PrivateUserAccess> for UserAccess {
+    fn from(access: PrivateUserAccess) -> Self {
+        UserAccess::Private(access)
+    }
+}
+
+impl From<PublicUserAccess> for UserAccess {
+    fn from(access: PublicUserAccess) -> Self {
+        UserAccess::Public(access)
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash, Debug)]
+pub struct PrivateUserAccess {
+    status: BTreeMap<AccessType, bool>,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash, Debug)]
+pub struct PublicUserAccess {
+    status: BTreeMap<AccessType, bool>,
+}
+
+impl PrivateUserAccess {
+    pub fn new(status: BTreeMap<AccessType, bool>) -> Self {
+        PrivateUserAccess { status }
+    }
+
+    pub fn set(&mut self, status: BTreeMap<AccessType, bool>) {
+        self.status = status;
+    }
+
+    pub fn is_allowed(self, access: &AccessType) -> bool {
+        match self.status.get(access) {
+            Some(true) => true,
+            _ => false,
+        }
+    }
+}
+
+impl PublicUserAccess {
+    pub fn new(status: BTreeMap<AccessType, bool>) -> Self {
+        PublicUserAccess { status }
+    }
+
+    pub fn set(&mut self, status: BTreeMap<AccessType, bool>) {
+        self.status = status; // todo: filter out Queries
+    }
+
+    /// Returns `Some(true)` if `access` is allowed and `Some(false)` if it's not.
+    /// `None` means that `User::Anyone` permissions apply.
+    pub fn is_allowed(self, access: &AccessType) -> Option<bool> {
+        match access {
+            AccessType::Read => Some(true), // It's Public data, so it's always allowed to read it.
+            _ => match self.status.get(access) {
+                Some(true) => Some(true),
+                Some(false) => Some(false),
+                None => None,
+            },
+        }
+    }
+}
+
+pub trait AccessListTrait: Clone + Eq + Ord + Hash + Serialize + DeserializeOwned {
+    fn is_allowed(&self, user: &PublicKey, access: &AccessType) -> bool;
+    fn expected_data_version(&self) -> u64;
+    fn expected_owners_version(&self) -> u64;
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash, Debug)]
+pub struct PrivateAccessList {
+    pub access_list: BTreeMap<PublicKey, PrivateUserAccess>,
+    /// The expected index of the data at the time this grant status change is to become valid.
+    pub expected_data_version: u64,
+    /// The expected index of the owners at the time this grant status is to become valid.
+    pub expected_owners_version: u64,
+}
+
+impl PrivateAccessList {
+    pub fn access_list(&self) -> &BTreeMap<PublicKey, PrivateUserAccess> {
+        &self.access_list
+    }
+}
+
+impl AccessListTrait for PrivateAccessList {
+    fn is_allowed(&self, user: &PublicKey, access: &AccessType) -> bool {
+        match self.access_list.get(user) {
+            Some(access_status) => access_status.clone().is_allowed(access),
+            None => false,
+        }
+    }
+
+    fn expected_data_version(&self) -> u64 {
+        self.expected_data_version
+    }
+
+    fn expected_owners_version(&self) -> u64 {
+        self.expected_owners_version
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash, Debug)]
+pub struct PublicAccessList {
+    pub access_list: BTreeMap<User, PublicUserAccess>,
+    /// The expected index of the data at the time this grant status change is to become valid.
+    pub expected_data_version: u64,
+    /// The expected index of the owners at the time this grant status change is to become valid.
+    pub expected_owners_version: u64,
+}
+
+impl PublicAccessList {
+    fn is_allowed_(&self, user: &User, access: &AccessType) -> Option<bool> {
+        match self.access_list.get(user) {
+            Some(status) => match status.clone().is_allowed(access) {
+                Some(true) => Some(true),
+                Some(false) => Some(false),
+                None => None,
+            },
+            _ => None,
+        }
+    }
+
+    pub fn access_list(&self) -> &BTreeMap<User, PublicUserAccess> {
+        &self.access_list
+    }
+}
+
+impl AccessListTrait for PublicAccessList {
+    fn is_allowed(&self, user: &PublicKey, access: &AccessType) -> bool {
+        match self.is_allowed_(&User::Specific(*user), access) {
+            Some(true) => true,
+            Some(false) => false,
+            None => match self.is_allowed_(&User::Anyone, access) {
+                Some(true) => true,
+                _ => false,
+            },
+        }
+    }
+
+    fn expected_data_version(&self) -> u64 {
+        self.expected_data_version
+    }
+
+    fn expected_owners_version(&self) -> u64 {
+        self.expected_owners_version
+    }
+}

--- a/src/authorization/mod.rs
+++ b/src/authorization/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+pub mod access_control;
+mod tests;
+pub use access_control::{
+    AccessList, AccessListTrait, AccessType, PrivateAccessList, PrivateUserAccess,
+    PublicAccessList, PublicUserAccess, UserAccess,
+};

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -7,8 +7,9 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-pub mod access_control;
-pub use access_control::{
-    AccessList, AccessListTrait, AccessType, PrivateAccessList, PrivateUserAccess,
-    PublicAccessList, PublicUserAccess, UserAccess,
+pub mod sequence;
+mod tests;
+pub use sequence::{
+    AppendOperation, DataEntry as SequenceEntry, PrivateSentriedSequence, PrivateSequence,
+    PublicSentriedSequence, PublicSequence, SequenceBase, SequenceData, Values as SequenceValues,
 };

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -8,6 +8,7 @@
 // Software.
 
 pub mod sequence;
+#[cfg(test)]
 mod tests;
 pub use sequence::{
     AppendOperation, DataEntry as SequenceEntry, PrivateSentriedSequence, PrivateSequence,

--- a/src/data/sequence.rs
+++ b/src/data/sequence.rs
@@ -1,0 +1,753 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+use crate::authorization::{
+    AccessListTrait, AccessType, PrivateAccessList, PrivateUserAccess, PublicAccessList,
+    PublicUserAccess,
+};
+use crate::shared_types::{
+    to_absolute_range, to_absolute_version, Address, ExpectedVersions, Kind, NonSentried, Owner,
+    Sentried, User, Value, Version,
+};
+use crate::{Error, PublicKey, Result, XorName};
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Debug, Formatter};
+
+pub type PublicSentriedSequence = SequenceBase<PublicAccessList, Sentried>;
+pub type PublicSequence = SequenceBase<PublicAccessList, NonSentried>;
+pub type PrivateSentriedSequence = SequenceBase<PrivateAccessList, Sentried>;
+pub type PrivateSequence = SequenceBase<PrivateAccessList, NonSentried>;
+pub type Values = Vec<Value>;
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default, Debug)]
+pub struct DataEntry {
+    pub version: u64,
+    pub value: Vec<u8>,
+}
+
+impl DataEntry {
+    pub fn new(version: u64, value: Vec<u8>) -> Self {
+        Self { version, value }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash)]
+pub struct SequenceBase<P, S> {
+    address: Address,
+    data: Values,
+    access_list: Vec<P>,
+    // This is the history of owners, with each entry representing an owner.  Each single owner
+    // could represent an individual user, or a group of users, depending on the `PublicKey` type.
+    owners: Vec<Owner>,
+    _flavour: S,
+}
+
+/// Common methods for all `Sequence` flavours.
+impl<C, S> SequenceBase<C, S>
+where
+    C: AccessListTrait,
+    S: Copy,
+{
+    pub fn is_allowed(&self, user: PublicKey, access: AccessType) -> bool {
+        match self.owner_at(Version::FromEnd(1)) {
+            Some(owner) => {
+                if owner.public_key == user {
+                    return true;
+                }
+            }
+            None => (),
+        }
+        match self.access_list_at(Version::FromEnd(1)) {
+            Some(list) => list.is_allowed(&user, &access),
+            None => false,
+        }
+    }
+
+    /// Return the address of this Sequence.
+    pub fn address(&self) -> &Address {
+        &self.address
+    }
+
+    /// Return the name of this Sequence.
+    pub fn name(&self) -> &XorName {
+        self.address.name()
+    }
+
+    /// Return the type tag of this Sequence.
+    pub fn tag(&self) -> u64 {
+        self.address.tag()
+    }
+
+    /// Returns true if the user is the current owner.
+    pub fn is_owner(&self, user: PublicKey) -> bool {
+        match self.owner_at(Version::FromEnd(1)) {
+            Some(owner) => user == owner.public_key,
+            _ => false,
+        }
+    }
+
+    /// Return the expected data version.
+    pub fn expected_data_version(&self) -> u64 {
+        self.data.len() as u64
+    }
+
+    /// Return the expected owners version.
+    pub fn expected_owners_version(&self) -> u64 {
+        self.owners.len() as u64
+    }
+
+    /// Return the expected access list version.
+    pub fn expected_access_list_version(&self) -> u64 {
+        self.access_list.len() as u64
+    }
+
+    pub fn versions(&self) -> ExpectedVersions {
+        ExpectedVersions::new(
+            self.expected_data_version(),
+            self.expected_owners_version(),
+            self.expected_access_list_version(),
+        )
+    }
+
+    /// Returns the data shell - that is - everything except the Values themselves.
+    pub fn shell(&self, expected_data_version: impl Into<Version>) -> Result<Self> {
+        let expected_data_version = to_absolute_version(
+            expected_data_version.into(),
+            self.expected_data_version() as usize,
+        )
+        .ok_or(Error::NoSuchEntry)? as u64;
+
+        let access_list = self
+            .access_list
+            .iter()
+            .filter(|a| a.expected_data_version() <= expected_data_version)
+            .cloned()
+            .collect();
+
+        let owners = self
+            .owners
+            .iter()
+            .filter(|owner| owner.expected_data_version <= expected_data_version)
+            .cloned()
+            .collect();
+
+        Ok(Self {
+            address: self.address,
+            data: Vec::new(),
+            access_list,
+            owners,
+            _flavour: self._flavour,
+        })
+    }
+
+    /// Return a value for the given Version (if it is present).
+    pub fn get(&self, version: Version) -> Option<&Value> {
+        let absolute_version = to_absolute_version(version, self.data.len())?;
+        self.data.get(absolute_version)
+    }
+
+    /// Return the current data entry (if it is present).
+    pub fn current_data_entry(&self) -> Option<DataEntry> {
+        match self.data.last() {
+            Some(value) => Some(DataEntry::new(self.data.len() as u64, value.to_vec())),
+            None => None,
+        }
+    }
+
+    /// Get a range of values within the given versions.
+    pub fn in_range(&self, start: Version, end: Version) -> Option<Values> {
+        let range = to_absolute_range(start, end, self.data.len())?;
+        Some(self.data[range].to_vec())
+    }
+
+    /// Return all Values.
+    pub fn values(&self) -> &Values {
+        &self.data
+    }
+
+    /// Get owner at version.
+    pub fn owner_at(&self, version: impl Into<Version>) -> Option<&Owner> {
+        let version = to_absolute_version(version.into(), self.owners.len())?;
+        self.owners.get(version)
+    }
+
+    /// Returns history of all owners
+    pub fn owner_history(&self) -> Vec<Owner> {
+        self.owners.clone()
+    }
+
+    /// Get history of owners within the range of versions specified.
+    pub fn owner_history_range(&self, start: Version, end: Version) -> Option<Vec<Owner>> {
+        let range = to_absolute_range(start, end, self.owners.len())?;
+        Some(self.owners[range].iter().map(|c| *c).collect())
+    }
+
+    /// Get access control at version.
+    pub fn access_list_at(&self, version: impl Into<Version>) -> Option<&C> {
+        let version = to_absolute_version(version.into(), self.access_list.len())?;
+        self.access_list.get(version)
+    }
+
+    /// Returns history of all access list states
+    pub fn access_list_history(&self) -> Vec<C> {
+        self.access_list.clone()
+    }
+
+    /// Get history of access list within the range of versions specified.
+    pub fn access_list_history_range(&self, start: Version, end: Version) -> Option<Vec<C>> {
+        let range = to_absolute_range(start, end, self.access_list.len())?;
+        Some(self.access_list[range].iter().map(|c| c.clone()).collect())
+    }
+
+    /// Set owner.
+    pub fn set_owner(&mut self, owner: Owner, expected_version: u64) -> Result<()> {
+        if owner.expected_data_version != self.expected_data_version() {
+            return Err(Error::InvalidSuccessor(self.expected_data_version()));
+        }
+        if owner.expected_access_list_version != self.expected_access_list_version() {
+            return Err(Error::InvalidPermissionsSuccessor(
+                self.expected_access_list_version(),
+            ));
+        }
+        if self.expected_owners_version() != expected_version {
+            return Err(Error::InvalidSuccessor(self.expected_owners_version()));
+        }
+        self.owners.push(owner);
+        Ok(())
+    }
+
+    /// Set access list.
+    /// The `AccessList` struct needs to contain the correct expected versions.
+    pub fn set_access_list(&mut self, access_list: &C, expected_version: u64) -> Result<()> {
+        if access_list.expected_data_version() != self.expected_data_version() {
+            return Err(Error::InvalidSuccessor(self.expected_data_version()));
+        }
+        if access_list.expected_owners_version() != self.expected_owners_version() {
+            return Err(Error::InvalidOwnersSuccessor(
+                self.expected_owners_version(),
+            ));
+        }
+        if self.expected_access_list_version() != expected_version {
+            return Err(Error::InvalidSuccessor(self.expected_access_list_version()));
+        }
+        self.access_list.push(access_list.clone()); // hmm... do we have to clone in situations like these?
+        Ok(())
+    }
+}
+
+#[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Serialize, Deserialize, Debug)]
+pub struct AppendOperation {
+    pub address: Address,
+    values: Values,
+    expected_version: Option<ExpectedVersion>,
+}
+
+impl AppendOperation {
+    pub fn new(
+        address: Address,
+        values: Values,
+        expected_version: Option<ExpectedVersion>,
+    ) -> Self {
+        Self {
+            address,
+            values,
+            expected_version,
+        }
+    }
+}
+
+pub type ExpectedVersion = u64;
+
+/// Common methods for NonSentried flavours.
+impl<P: AccessListTrait> SequenceBase<P, NonSentried> {
+    /// Append new Values.
+    pub fn append(&mut self, values: Values) -> Result<()> {
+        self.data.extend(values);
+        Ok(())
+    }
+}
+
+/// Common methods for Sentried flavours.
+impl<P: AccessListTrait> SequenceBase<P, Sentried> {
+    /// Append new Values.
+    ///
+    /// If the specified `expected_version` does not equal the Values count in data, an
+    /// error will be returned.
+    pub fn append(&mut self, values: Values, expected_version: u64) -> Result<()> {
+        if expected_version != self.data.len() as u64 {
+            return Err(Error::InvalidSuccessor(self.data.len() as u64));
+        }
+
+        self.data.extend(values);
+        Ok(())
+    }
+}
+
+/// Public + Sentried
+impl SequenceBase<PublicAccessList, Sentried> {
+    pub fn new(name: XorName, tag: u64) -> Self {
+        Self {
+            address: Address::PublicSentried { name, tag },
+            data: Vec::new(),
+            access_list: Vec::new(),
+            owners: Vec::new(),
+            _flavour: Sentried,
+        }
+    }
+}
+
+impl Debug for SequenceBase<PublicAccessList, Sentried> {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "PublicSentriedSequence {:?}", self.name())
+    }
+}
+
+/// Public + NonSentried
+impl SequenceBase<PublicAccessList, NonSentried> {
+    pub fn new(name: XorName, tag: u64) -> Self {
+        Self {
+            address: Address::Public { name, tag },
+            data: Vec::new(),
+            access_list: Vec::new(),
+            owners: Vec::new(),
+            _flavour: NonSentried,
+        }
+    }
+}
+
+impl Debug for SequenceBase<PublicAccessList, NonSentried> {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "PublicSequence {:?}", self.name())
+    }
+}
+
+/// Private + Sentried
+impl SequenceBase<PrivateAccessList, Sentried> {
+    pub fn new(name: XorName, tag: u64) -> Self {
+        Self {
+            address: Address::PrivateSentried { name, tag },
+            data: Vec::new(),
+            access_list: Vec::new(),
+            owners: Vec::new(),
+            _flavour: Sentried,
+        }
+    }
+}
+
+impl Debug for SequenceBase<PrivateAccessList, Sentried> {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "PrivateSentriedSequence {:?}", self.name())
+    }
+}
+
+/// Private + NonSentried
+impl SequenceBase<PrivateAccessList, NonSentried> {
+    pub fn new(name: XorName, tag: u64) -> Self {
+        Self {
+            address: Address::Private { name, tag },
+            data: Vec::new(),
+            access_list: Vec::new(),
+            owners: Vec::new(),
+            _flavour: NonSentried,
+        }
+    }
+}
+
+impl Debug for SequenceBase<PrivateAccessList, NonSentried> {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "PrivateSequence {:?}", self.name())
+    }
+}
+
+/// Object storing a Sequence variant.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
+pub enum SequenceData {
+    PublicSentried(PublicSentriedSequence),
+    Public(PublicSequence),
+    PrivateSentried(PrivateSentriedSequence),
+    Private(PrivateSequence),
+}
+
+impl SequenceData {
+    pub fn is_allowed(&self, access: AccessType, user: PublicKey) -> bool {
+        use AccessType::*;
+        use SequenceData::*;
+        // Public flavours automatically allows all reads.
+        match (self, access) {
+            (PublicSentried(_), Read) | (Public(_), Read) => return true,
+            _ => (),
+        }
+        match (self, access) {
+            (PublicSentried(data), Append) | (PublicSentried(data), ModifyPermissions) => {
+                data.is_allowed(user, access)
+            }
+            (Public(data), Append) | (Public(data), ModifyPermissions) => {
+                data.is_allowed(user, access)
+            }
+
+            (PrivateSentried(data), Append) | (PrivateSentried(data), ModifyPermissions) => {
+                data.is_allowed(user, access)
+            }
+            (Private(data), Append) | (Private(data), ModifyPermissions) => {
+                data.is_allowed(user, access)
+            }
+            (PrivateSentried(data), Read) => data.is_allowed(user, access),
+            (Private(data), Read) => data.is_allowed(user, access),
+            _ => false,
+        }
+    }
+
+    pub fn address(&self) -> &Address {
+        use SequenceData::*;
+        match self {
+            PublicSentried(data) => data.address(),
+            Public(data) => data.address(),
+            PrivateSentried(data) => data.address(),
+            Private(data) => data.address(),
+        }
+    }
+
+    pub fn kind(&self) -> Kind {
+        self.address().kind()
+    }
+
+    pub fn name(&self) -> &XorName {
+        self.address().name()
+    }
+
+    pub fn tag(&self) -> u64 {
+        self.address().tag()
+    }
+
+    pub fn is_public(&self) -> bool {
+        self.kind().is_public()
+    }
+
+    pub fn is_private(&self) -> bool {
+        self.kind().is_private()
+    }
+
+    pub fn is_sentried(&self) -> bool {
+        self.kind().is_sentried()
+    }
+
+    pub fn is_owner(&self, user: PublicKey) -> bool {
+        use SequenceData::*;
+        match self {
+            PublicSentried(data) => data.is_owner(user),
+            Public(data) => data.is_owner(user),
+            PrivateSentried(data) => data.is_owner(user),
+            Private(data) => data.is_owner(user),
+        }
+    }
+
+    pub fn expected_data_version(&self) -> u64 {
+        use SequenceData::*;
+        match self {
+            PublicSentried(data) => data.expected_data_version(),
+            Public(data) => data.expected_data_version(),
+            PrivateSentried(data) => data.expected_data_version(),
+            Private(data) => data.expected_data_version(),
+        }
+    }
+
+    pub fn expected_access_list_version(&self) -> u64 {
+        use SequenceData::*;
+        match self {
+            PublicSentried(data) => data.expected_access_list_version(),
+            Public(data) => data.expected_access_list_version(),
+            PrivateSentried(data) => data.expected_access_list_version(),
+            Private(data) => data.expected_access_list_version(),
+        }
+    }
+
+    pub fn expected_owners_version(&self) -> u64 {
+        use SequenceData::*;
+        match self {
+            PublicSentried(data) => data.expected_owners_version(),
+            Public(data) => data.expected_owners_version(),
+            PrivateSentried(data) => data.expected_owners_version(),
+            Private(data) => data.expected_owners_version(),
+        }
+    }
+
+    pub fn versions(&self) -> ExpectedVersions {
+        use SequenceData::*;
+        match self {
+            PublicSentried(data) => data.versions(),
+            Public(data) => data.versions(),
+            PrivateSentried(data) => data.versions(),
+            Private(data) => data.versions(),
+        }
+    }
+
+    pub fn get(&self, version: Version) -> Option<&Value> {
+        use SequenceData::*;
+        match self {
+            PublicSentried(data) => data.get(version),
+            Public(data) => data.get(version),
+            PrivateSentried(data) => data.get(version),
+            Private(data) => data.get(version),
+        }
+    }
+
+    pub fn current_data_entry(&self) -> Option<DataEntry> {
+        use SequenceData::*;
+        match self {
+            PublicSentried(data) => data.current_data_entry(),
+            Public(data) => data.current_data_entry(),
+            PrivateSentried(data) => data.current_data_entry(),
+            Private(data) => data.current_data_entry(),
+        }
+    }
+
+    pub fn in_range(&self, start: Version, end: Version) -> Option<Values> {
+        use SequenceData::*;
+        match self {
+            PublicSentried(data) => data.in_range(start, end),
+            Public(data) => data.in_range(start, end),
+            PrivateSentried(data) => data.in_range(start, end),
+            Private(data) => data.in_range(start, end),
+        }
+    }
+
+    pub fn owner_at(&self, version: impl Into<Version>) -> Option<&Owner> {
+        use SequenceData::*;
+        match self {
+            PublicSentried(data) => data.owner_at(version),
+            Public(data) => data.owner_at(version),
+            PrivateSentried(data) => data.owner_at(version),
+            Private(data) => data.owner_at(version),
+        }
+    }
+
+    /// Returns history of all owners
+    pub fn owner_history(&self) -> Result<Vec<Owner>> {
+        use SequenceData::*;
+        let result = match self {
+            PublicSentried(data) => Some(data.owner_history()),
+            Public(data) => Some(data.owner_history()),
+            PrivateSentried(data) => Some(data.owner_history()),
+            Private(data) => Some(data.owner_history()),
+        };
+        result.ok_or(Error::NoSuchEntry)
+    }
+
+    /// Get history of owners within the range of versions specified.
+    pub fn owner_history_range(&self, start: Version, end: Version) -> Result<Vec<Owner>> {
+        use SequenceData::*;
+        let result = match self {
+            PublicSentried(data) => data.owner_history_range(start, end),
+            Public(data) => data.owner_history_range(start, end),
+            PrivateSentried(data) => data.owner_history_range(start, end),
+            Private(data) => data.owner_history_range(start, end),
+        };
+        result.ok_or(Error::NoSuchEntry)
+    }
+
+    pub fn public_user_access_at(
+        &self,
+        user: User,
+        version: impl Into<Version>,
+    ) -> Result<PublicUserAccess> {
+        self.public_access_list_at(version)?
+            .access_list()
+            .get(&user)
+            .cloned()
+            .ok_or(Error::NoSuchEntry)
+    }
+
+    pub fn private_user_access_at(
+        &self,
+        user: PublicKey,
+        version: impl Into<Version>,
+    ) -> Result<PrivateUserAccess> {
+        self.private_access_list_at(version)?
+            .access_list()
+            .get(&user)
+            .cloned()
+            .ok_or(Error::NoSuchEntry)
+    }
+
+    pub fn public_access_list_at(&self, version: impl Into<Version>) -> Result<&PublicAccessList> {
+        use SequenceData::*;
+        let access_list = match self {
+            PublicSentried(data) => data.access_list_at(version),
+            Public(data) => data.access_list_at(version),
+            _ => return Err(Error::InvalidOperation),
+        };
+        access_list.ok_or(Error::NoSuchEntry)
+    }
+
+    pub fn private_access_list_at(
+        &self,
+        version: impl Into<Version>,
+    ) -> Result<&PrivateAccessList> {
+        use SequenceData::*;
+        let access_list = match self {
+            PrivateSentried(data) => data.access_list_at(version),
+            Private(data) => data.access_list_at(version),
+            _ => return Err(Error::InvalidOperation),
+        };
+        access_list.ok_or(Error::NoSuchEntry)
+    }
+
+    /// Returns history of all access list states
+    pub fn public_access_list_history(&self) -> Result<Vec<PublicAccessList>> {
+        use SequenceData::*;
+        let result = match self {
+            PublicSentried(data) => Some(data.access_list_history()),
+            Public(data) => Some(data.access_list_history()),
+            _ => return Err(Error::InvalidOperation),
+        };
+        result.ok_or(Error::NoSuchEntry)
+    }
+
+    /// Returns history of all access list states
+    pub fn private_access_list_history(&self) -> Result<Vec<PrivateAccessList>> {
+        use SequenceData::*;
+        let result = match self {
+            PrivateSentried(data) => Some(data.access_list_history()),
+            Private(data) => Some(data.access_list_history()),
+            _ => return Err(Error::InvalidOperation),
+        };
+        result.ok_or(Error::NoSuchEntry)
+    }
+
+    /// Get history of access list within the range of versions specified.
+    pub fn public_access_list_history_range(
+        &self,
+        start: Version,
+        end: Version,
+    ) -> Result<Vec<PublicAccessList>> {
+        use SequenceData::*;
+        let result = match self {
+            PublicSentried(data) => data.access_list_history_range(start, end),
+            Public(data) => data.access_list_history_range(start, end),
+            _ => return Err(Error::InvalidOperation),
+        };
+        result.ok_or(Error::NoSuchEntry)
+    }
+
+    /// Get history of access list within the range of versions specified.
+    pub fn private_access_list_history_range(
+        &self,
+        start: Version,
+        end: Version,
+    ) -> Result<Vec<PrivateAccessList>> {
+        use SequenceData::*;
+        let result = match self {
+            PrivateSentried(data) => data.access_list_history_range(start, end),
+            Private(data) => data.access_list_history_range(start, end),
+            _ => return Err(Error::InvalidOperation),
+        };
+        result.ok_or(Error::NoSuchEntry)
+    }
+
+    pub fn shell(&self, version: impl Into<Version>) -> Result<Self> {
+        use SequenceData::*;
+        match self {
+            PublicSentried(adata) => adata.shell(version).map(PublicSentried),
+            Public(adata) => adata.shell(version).map(Public),
+            PrivateSentried(adata) => adata.shell(version).map(PrivateSentried),
+            Private(adata) => adata.shell(version).map(Private),
+        }
+    }
+
+    pub fn set_owner(&mut self, owner: Owner, expected_version: u64) -> Result<()> {
+        use SequenceData::*;
+        match self {
+            PublicSentried(adata) => adata.set_owner(owner, expected_version),
+            Public(adata) => adata.set_owner(owner, expected_version),
+            PrivateSentried(adata) => adata.set_owner(owner, expected_version),
+            Private(adata) => adata.set_owner(owner, expected_version),
+        }
+    }
+
+    pub fn set_private_access_list(
+        &mut self,
+        access_list: &PrivateAccessList,
+        expected_version: u64,
+    ) -> Result<()> {
+        use SequenceData::*;
+        match self {
+            Private(data) => data.set_access_list(access_list, expected_version),
+            PrivateSentried(data) => data.set_access_list(access_list, expected_version),
+            _ => Err(Error::InvalidOperation),
+        }
+    }
+
+    pub fn set_public_access_list(
+        &mut self,
+        access_list: &PublicAccessList,
+        expected_version: u64,
+    ) -> Result<()> {
+        use SequenceData::*;
+        match self {
+            Public(data) => data.set_access_list(access_list, expected_version),
+            PublicSentried(data) => data.set_access_list(access_list, expected_version),
+            _ => Err(Error::InvalidOperation),
+        }
+    }
+
+    /// Appends values.
+    pub fn append(&mut self, operation: &AppendOperation) -> Result<()> {
+        use SequenceData::*;
+        match self {
+            PrivateSentried(sequence) => match operation.expected_version {
+                Some(expected_version) => {
+                    return sequence.append(operation.values.to_vec(), expected_version);
+                }
+                _ => return Err(Error::InvalidOperation),
+            },
+            Private(sequence) => match operation.expected_version {
+                None => {
+                    return sequence.append(operation.values.to_vec());
+                }
+                _ => return Err(Error::InvalidOperation),
+            },
+            PublicSentried(sequence) => match operation.expected_version {
+                Some(expected_version) => {
+                    return sequence.append(operation.values.to_vec(), expected_version);
+                }
+                _ => return Err(Error::InvalidOperation),
+            },
+            Public(sequence) => match operation.expected_version {
+                None => {
+                    return sequence.append(operation.values.to_vec());
+                }
+                _ => return Err(Error::InvalidOperation),
+            },
+        }
+    }
+}
+
+impl From<PublicSentriedSequence> for SequenceData {
+    fn from(data: PublicSentriedSequence) -> Self {
+        SequenceData::PublicSentried(data)
+    }
+}
+
+impl From<PublicSequence> for SequenceData {
+    fn from(data: PublicSequence) -> Self {
+        SequenceData::Public(data)
+    }
+}
+
+impl From<PrivateSentriedSequence> for SequenceData {
+    fn from(data: PrivateSentriedSequence) -> Self {
+        SequenceData::PrivateSentried(data)
+    }
+}
+
+impl From<PrivateSequence> for SequenceData {
+    fn from(data: PrivateSequence) -> Self {
+        SequenceData::Private(data)
+    }
+}

--- a/src/data/tests.rs
+++ b/src/data/tests.rs
@@ -1,0 +1,125 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+#[cfg(test)]
+mod tests {
+    use crate::data::sequence::*;
+    use crate::shared_types::Version;
+    use crate::XorName;
+    use unwrap::unwrap;
+
+    #[test]
+    fn append_sentried_data() {
+        let mut data = PublicSentriedSequence::new(XorName([1; 32]), 10000);
+        unwrap!(data.append(vec![b"hello".to_vec(), b"world".to_vec()], 0));
+    }
+
+    #[test]
+    fn append_private_data() {
+        let mut data = PrivateSequence::new(XorName(rand::random()), 10);
+
+        // Assert that the Values are appended.
+        let values1 = vec![
+            b"KEY1".to_vec(),
+            b"VALUE1".to_vec(),
+            b"KEY2".to_vec(),
+            b"VALUE2".to_vec(),
+        ];
+
+        unwrap!(data.append(values1));
+    }
+
+    #[test]
+    fn append_private_sentried_data() {
+        let mut data = PrivateSentriedSequence::new(XorName(rand::random()), 10);
+
+        // Assert that the values are appended.
+        let values1 = vec![
+            b"KEY1".to_vec(),
+            b"VALUE1".to_vec(),
+            b"KEY2".to_vec(),
+            b"VALUE2".to_vec(),
+        ];
+        unwrap!(data.append(values1, 0));
+    }
+
+    #[test]
+    fn in_range() {
+        let mut data = PublicSentriedSequence::new(rand::random(), 10);
+        let values = vec![
+            b"key0".to_vec(),
+            b"value0".to_vec(),
+            b"key1".to_vec(),
+            b"value1".to_vec(),
+        ];
+        unwrap!(data.append(values, 0));
+
+        assert_eq!(
+            data.in_range(Version::FromStart(0), Version::FromStart(0)),
+            Some(vec![])
+        );
+        assert_eq!(
+            data.in_range(Version::FromStart(0), Version::FromStart(2)),
+            Some(vec![b"key0".to_vec(), b"value0".to_vec()])
+        );
+        assert_eq!(
+            data.in_range(Version::FromStart(0), Version::FromStart(4)),
+            Some(vec![
+                b"key0".to_vec(),
+                b"value0".to_vec(),
+                b"key1".to_vec(),
+                b"value1".to_vec(),
+            ])
+        );
+
+        assert_eq!(
+            data.in_range(Version::FromEnd(4), Version::FromEnd(2)),
+            Some(vec![b"key0".to_vec(), b"value0".to_vec(),])
+        );
+        assert_eq!(
+            data.in_range(Version::FromEnd(4), Version::FromEnd(0)),
+            Some(vec![
+                b"key0".to_vec(),
+                b"value0".to_vec(),
+                b"key1".to_vec(),
+                b"value1".to_vec(),
+            ])
+        );
+
+        assert_eq!(
+            data.in_range(Version::FromStart(0), Version::FromEnd(0)),
+            Some(vec![
+                b"key0".to_vec(),
+                b"value0".to_vec(),
+                b"key1".to_vec(),
+                b"value1".to_vec(),
+            ])
+        );
+
+        // start > end
+        assert_eq!(
+            data.in_range(Version::FromStart(1), Version::FromStart(0)),
+            None
+        );
+        assert_eq!(
+            data.in_range(Version::FromEnd(1), Version::FromEnd(2)),
+            None
+        );
+
+        // overflow
+        assert_eq!(
+            data.in_range(Version::FromStart(0), Version::FromStart(5)),
+            None
+        );
+        assert_eq!(
+            data.in_range(Version::FromEnd(5), Version::FromEnd(0)),
+            None
+        );
+    }
+}

--- a/src/data/tests.rs
+++ b/src/data/tests.rs
@@ -7,119 +7,116 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-#[cfg(test)]
-mod tests {
-    use crate::data::sequence::*;
-    use crate::shared_types::Version;
-    use crate::XorName;
-    use unwrap::unwrap;
+use crate::data::sequence::*;
+use crate::shared_types::Version;
+use crate::XorName;
+use unwrap::unwrap;
 
-    #[test]
-    fn append_sentried_data() {
-        let mut data = PublicSentriedSequence::new(XorName([1; 32]), 10000);
-        unwrap!(data.append(vec![b"hello".to_vec(), b"world".to_vec()], 0));
-    }
+#[test]
+fn append_sentried_data() {
+    let mut data = PublicSentriedSequence::new(XorName([1; 32]), 10000);
+    unwrap!(data.append(vec![b"hello".to_vec(), b"world".to_vec()], 0));
+}
 
-    #[test]
-    fn append_private_data() {
-        let mut data = PrivateSequence::new(XorName(rand::random()), 10);
+#[test]
+fn append_private_data() {
+    let mut data = PrivateSequence::new(XorName(rand::random()), 10);
 
-        // Assert that the Values are appended.
-        let values1 = vec![
-            b"KEY1".to_vec(),
-            b"VALUE1".to_vec(),
-            b"KEY2".to_vec(),
-            b"VALUE2".to_vec(),
-        ];
+    // Assert that the Values are appended.
+    let values1 = vec![
+        b"KEY1".to_vec(),
+        b"VALUE1".to_vec(),
+        b"KEY2".to_vec(),
+        b"VALUE2".to_vec(),
+    ];
 
-        unwrap!(data.append(values1));
-    }
+    unwrap!(data.append(values1));
+}
 
-    #[test]
-    fn append_private_sentried_data() {
-        let mut data = PrivateSentriedSequence::new(XorName(rand::random()), 10);
+#[test]
+fn append_private_sentried_data() {
+    let mut data = PrivateSentriedSequence::new(XorName(rand::random()), 10);
 
-        // Assert that the values are appended.
-        let values1 = vec![
-            b"KEY1".to_vec(),
-            b"VALUE1".to_vec(),
-            b"KEY2".to_vec(),
-            b"VALUE2".to_vec(),
-        ];
-        unwrap!(data.append(values1, 0));
-    }
+    // Assert that the values are appended.
+    let values1 = vec![
+        b"KEY1".to_vec(),
+        b"VALUE1".to_vec(),
+        b"KEY2".to_vec(),
+        b"VALUE2".to_vec(),
+    ];
+    unwrap!(data.append(values1, 0));
+}
 
-    #[test]
-    fn in_range() {
-        let mut data = PublicSentriedSequence::new(rand::random(), 10);
-        let values = vec![
+#[test]
+fn in_range() {
+    let mut data = PublicSentriedSequence::new(rand::random(), 10);
+    let values = vec![
+        b"key0".to_vec(),
+        b"value0".to_vec(),
+        b"key1".to_vec(),
+        b"value1".to_vec(),
+    ];
+    unwrap!(data.append(values, 0));
+
+    assert_eq!(
+        data.in_range(Version::FromStart(0), Version::FromStart(0)),
+        Some(vec![])
+    );
+    assert_eq!(
+        data.in_range(Version::FromStart(0), Version::FromStart(2)),
+        Some(vec![b"key0".to_vec(), b"value0".to_vec()])
+    );
+    assert_eq!(
+        data.in_range(Version::FromStart(0), Version::FromStart(4)),
+        Some(vec![
             b"key0".to_vec(),
             b"value0".to_vec(),
             b"key1".to_vec(),
             b"value1".to_vec(),
-        ];
-        unwrap!(data.append(values, 0));
+        ])
+    );
 
-        assert_eq!(
-            data.in_range(Version::FromStart(0), Version::FromStart(0)),
-            Some(vec![])
-        );
-        assert_eq!(
-            data.in_range(Version::FromStart(0), Version::FromStart(2)),
-            Some(vec![b"key0".to_vec(), b"value0".to_vec()])
-        );
-        assert_eq!(
-            data.in_range(Version::FromStart(0), Version::FromStart(4)),
-            Some(vec![
-                b"key0".to_vec(),
-                b"value0".to_vec(),
-                b"key1".to_vec(),
-                b"value1".to_vec(),
-            ])
-        );
+    assert_eq!(
+        data.in_range(Version::FromEnd(4), Version::FromEnd(2)),
+        Some(vec![b"key0".to_vec(), b"value0".to_vec(),])
+    );
+    assert_eq!(
+        data.in_range(Version::FromEnd(4), Version::FromEnd(0)),
+        Some(vec![
+            b"key0".to_vec(),
+            b"value0".to_vec(),
+            b"key1".to_vec(),
+            b"value1".to_vec(),
+        ])
+    );
 
-        assert_eq!(
-            data.in_range(Version::FromEnd(4), Version::FromEnd(2)),
-            Some(vec![b"key0".to_vec(), b"value0".to_vec(),])
-        );
-        assert_eq!(
-            data.in_range(Version::FromEnd(4), Version::FromEnd(0)),
-            Some(vec![
-                b"key0".to_vec(),
-                b"value0".to_vec(),
-                b"key1".to_vec(),
-                b"value1".to_vec(),
-            ])
-        );
+    assert_eq!(
+        data.in_range(Version::FromStart(0), Version::FromEnd(0)),
+        Some(vec![
+            b"key0".to_vec(),
+            b"value0".to_vec(),
+            b"key1".to_vec(),
+            b"value1".to_vec(),
+        ])
+    );
 
-        assert_eq!(
-            data.in_range(Version::FromStart(0), Version::FromEnd(0)),
-            Some(vec![
-                b"key0".to_vec(),
-                b"value0".to_vec(),
-                b"key1".to_vec(),
-                b"value1".to_vec(),
-            ])
-        );
+    // start > end
+    assert_eq!(
+        data.in_range(Version::FromStart(1), Version::FromStart(0)),
+        None
+    );
+    assert_eq!(
+        data.in_range(Version::FromEnd(1), Version::FromEnd(2)),
+        None
+    );
 
-        // start > end
-        assert_eq!(
-            data.in_range(Version::FromStart(1), Version::FromStart(0)),
-            None
-        );
-        assert_eq!(
-            data.in_range(Version::FromEnd(1), Version::FromEnd(2)),
-            None
-        );
-
-        // overflow
-        assert_eq!(
-            data.in_range(Version::FromStart(0), Version::FromStart(5)),
-            None
-        );
-        assert_eq!(
-            data.in_range(Version::FromEnd(5), Version::FromEnd(0)),
-            None
-        );
-    }
+    // overflow
+    assert_eq!(
+        data.in_range(Version::FromStart(0), Version::FromStart(5)),
+        None
+    );
+    assert_eq!(
+        data.in_range(Version::FromEnd(5), Version::FromEnd(0)),
+        None
+    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,9 @@
 )]
 
 mod append_only_data;
+mod authorization;
 mod coins;
+mod data;
 mod errors;
 mod identity;
 mod immutable_data;
@@ -37,6 +39,7 @@ mod keys;
 mod mutable_data;
 mod request;
 mod response;
+mod shared_types;
 mod utils;
 
 pub use append_only_data::{

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -1,0 +1,213 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+use crate::{utils, PublicKey, Result, XorName};
+use multibase::Decodable;
+use serde::{Deserialize, Serialize};
+use std::ops::Range;
+
+pub type Key = Vec<u8>;
+pub type Value = Vec<u8>;
+pub type KvPair = (Key, Value);
+pub type Values = Vec<Value>;
+pub type Keys = Vec<Key>;
+
+/// Marker for sentried data.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
+pub struct Sentried;
+
+/// Marker for non-sentried data.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
+pub struct NonSentried;
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
+pub enum User {
+    Anyone,
+    Specific(PublicKey),
+}
+
+#[derive(Copy, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum Version {
+    FromStart(u64), // Absolute index
+    FromEnd(u64),   // Relative Version - start counting from the end
+}
+
+impl From<u64> for Version {
+    fn from(version: u64) -> Self {
+        Version::FromStart(version)
+    }
+}
+
+// Set of data, owners, permissions versions.
+#[derive(Copy, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ExpectedVersions {
+    expected_data_version: u64,
+    expected_owners_version: u64,
+    expected_access_list_version: u64,
+}
+
+impl ExpectedVersions {
+    pub fn new(
+        expected_data_version: u64,
+        expected_owners_version: u64,
+        expected_access_list_version: u64,
+    ) -> Self {
+        ExpectedVersions {
+            expected_data_version,
+            expected_owners_version,
+            expected_access_list_version,
+        }
+    }
+
+    pub fn expected_data_version(&self) -> u64 {
+        self.expected_data_version
+    }
+
+    pub fn expected_owners_version(&self) -> u64 {
+        self.expected_owners_version
+    }
+
+    pub fn expected_access_list_version(&self) -> u64 {
+        self.expected_access_list_version
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
+pub struct Owner {
+    pub public_key: PublicKey,
+    /// The expected Version of the data at the time this ownership change is to become valid.
+    pub expected_data_version: u64,
+    /// The expected Version of the permissions at the time this ownership change is to become valid.
+    pub expected_access_list_version: u64,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
+pub enum Kind {
+    PublicSentried,
+    Public,
+    PrivateSentried,
+    Private,
+}
+
+impl Kind {
+    pub fn is_public(self) -> bool {
+        self == Kind::PublicSentried || self == Kind::Public
+    }
+
+    pub fn is_private(self) -> bool {
+        !self.is_public()
+    }
+
+    pub fn is_sentried(self) -> bool {
+        self == Kind::PublicSentried || self == Kind::PrivateSentried
+    }
+
+    /// Creates `Kind` from `public` and `sentried` flags.
+    pub fn from_flags(public: bool, sentried: bool) -> Self {
+        match (public, sentried) {
+            (true, true) => Kind::PublicSentried,
+            (true, false) => Kind::Public,
+            (false, true) => Kind::PrivateSentried,
+            (false, false) => Kind::Private,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
+pub enum DataAddress {
+    Map(Address),
+    Sequence(Address),
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
+pub enum Address {
+    PublicSentried { name: XorName, tag: u64 },
+    Public { name: XorName, tag: u64 },
+    PrivateSentried { name: XorName, tag: u64 },
+    Private { name: XorName, tag: u64 },
+}
+
+impl Address {
+    pub fn from_kind(kind: Kind, name: XorName, tag: u64) -> Self {
+        match kind {
+            Kind::PublicSentried => Address::PublicSentried { name, tag },
+            Kind::Public => Address::Public { name, tag },
+            Kind::PrivateSentried => Address::PrivateSentried { name, tag },
+            Kind::Private => Address::Private { name, tag },
+        }
+    }
+
+    pub fn kind(&self) -> Kind {
+        match self {
+            Address::PublicSentried { .. } => Kind::PublicSentried,
+            Address::Public { .. } => Kind::Public,
+            Address::PrivateSentried { .. } => Kind::PrivateSentried,
+            Address::Private { .. } => Kind::Private,
+        }
+    }
+
+    pub fn name(&self) -> &XorName {
+        match self {
+            Address::PublicSentried { ref name, .. }
+            | Address::Public { ref name, .. }
+            | Address::PrivateSentried { ref name, .. }
+            | Address::Private { ref name, .. } => name,
+        }
+    }
+
+    pub fn tag(&self) -> u64 {
+        match self {
+            Address::PublicSentried { tag, .. }
+            | Address::Public { tag, .. }
+            | Address::PrivateSentried { tag, .. }
+            | Address::Private { tag, .. } => *tag,
+        }
+    }
+
+    pub fn is_public(&self) -> bool {
+        self.kind().is_public()
+    }
+
+    pub fn is_private(&self) -> bool {
+        self.kind().is_private()
+    }
+
+    pub fn is_sentried(&self) -> bool {
+        self.kind().is_sentried()
+    }
+
+    /// Returns the Address serialised and encoded in z-base-32.
+    pub fn encode_to_zbase32(&self) -> String {
+        utils::encode(&self)
+    }
+
+    /// Create from z-base-32 encoded string.
+    pub fn decode_from_zbase32<I: Decodable>(encoded: I) -> Result<Self> {
+        utils::decode(encoded)
+    }
+}
+
+pub fn to_absolute_version(version: Version, count: usize) -> Option<usize> {
+    match version {
+        Version::FromStart(version) if version as usize <= count => Some(version as usize),
+        Version::FromStart(_) => None,
+        Version::FromEnd(version) => count.checked_sub(version as usize),
+    }
+}
+
+pub fn to_absolute_range(start: Version, end: Version, count: usize) -> Option<Range<usize>> {
+    let start = to_absolute_version(start, count)?;
+    let end = to_absolute_version(end, count)?;
+
+    if start <= end {
+        Some(start..end)
+    } else {
+        None
+    }
+}

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -7,6 +7,8 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
+#![allow(dead_code)] // for the draft PR only
+
 use crate::{utils, PublicKey, Result, XorName};
 use multibase::Decodable;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Draft for discussions with partial implementations.  **Not to be merged.**

**NB:** The draft is primarily intended to focus on discussion about the **concept changes** and **idiomatic rust**. Small things, like typos or smallish wording changes in docs, indentation and similar trivialities can be addressed in the real PR (if they are still present). 
Anything off that is already present in current code base (i.e. not part of this change) could perhaps better go into a proper issue - as to keep discussion focused around the actual changes.

For the full implementation, see https://github.com/oetyng/safe-nd/tree/datatypes-refinement-demo

Based on `access_control` branch.

- Adds `sequence.rs` in `data` mod.
- Adds rudimentary tests for `sequence`.

Step **3.2** adds the `request` and `response` APIs for the `sequence` data type.