### PR TITLE
Refactor AppendOnlyData, step 4.1: Add Map

### DIFF
--- a/src/authorization/access_control.rs
+++ b/src/authorization/access_control.rs
@@ -92,8 +92,8 @@ impl PrivateUserAccess {
         self.status = status;
     }
 
-    pub fn is_allowed(self, access: &AccessType) -> bool {
-        match self.status.get(access) {
+    pub fn is_allowed(&self, access: AccessType) -> bool {
+        match self.status.get(&access) {
             Some(true) => true,
             _ => false,
         }
@@ -111,10 +111,10 @@ impl PublicUserAccess {
 
     /// Returns `Some(true)` if `access` is allowed and `Some(false)` if it's not.
     /// `None` means that `User::Anyone` permissions apply.
-    pub fn is_allowed(self, access: &AccessType) -> Option<bool> {
+    pub fn is_allowed(&self, access: AccessType) -> Option<bool> {
         match access {
             AccessType::Read => Some(true), // It's Public data, so it's always allowed to read it.
-            _ => match self.status.get(access) {
+            _ => match self.status.get(&access) {
                 Some(true) => Some(true),
                 Some(false) => Some(false),
                 None => None,
@@ -124,7 +124,7 @@ impl PublicUserAccess {
 }
 
 pub trait AccessListTrait: Clone + Eq + Ord + Hash + Serialize + DeserializeOwned {
-    fn is_allowed(&self, user: &PublicKey, access: &AccessType) -> bool;
+    fn is_allowed(&self, user: &PublicKey, access: AccessType) -> bool;
     fn expected_data_version(&self) -> u64;
     fn expected_owners_version(&self) -> u64;
 }
@@ -145,7 +145,7 @@ impl PrivateAccessList {
 }
 
 impl AccessListTrait for PrivateAccessList {
-    fn is_allowed(&self, user: &PublicKey, access: &AccessType) -> bool {
+    fn is_allowed(&self, user: &PublicKey, access: AccessType) -> bool {
         match self.access_list.get(user) {
             Some(access_status) => access_status.clone().is_allowed(access),
             None => false,
@@ -171,7 +171,7 @@ pub struct PublicAccessList {
 }
 
 impl PublicAccessList {
-    fn is_allowed_(&self, user: &User, access: &AccessType) -> Option<bool> {
+    fn is_allowed_(&self, user: &User, access: AccessType) -> Option<bool> {
         match self.access_list.get(user) {
             Some(status) => match status.clone().is_allowed(access) {
                 Some(true) => Some(true),
@@ -188,7 +188,7 @@ impl PublicAccessList {
 }
 
 impl AccessListTrait for PublicAccessList {
-    fn is_allowed(&self, user: &PublicKey, access: &AccessType) -> bool {
+    fn is_allowed(&self, user: &PublicKey, access: AccessType) -> bool {
         match self.is_allowed_(&User::Specific(*user), access) {
             Some(true) => true,
             Some(false) => false,

--- a/src/authorization/access_control.rs
+++ b/src/authorization/access_control.rs
@@ -1,0 +1,209 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+use crate::shared_types::User;
+use crate::PublicKey;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::{collections::BTreeMap, hash::Hash};
+
+/// ===========================================================
+///  Access control of data type instances and their content.
+/// ===========================================================
+
+/// The type of access to the native data structures.
+#[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub enum AccessType {
+    /// Read data, owners and permissions.
+    Read,
+    /// Append new values.
+    Append,
+    /// Insert new values.
+    Insert,
+    /// Soft-update existing values.
+    Update,
+    /// Soft-delete existing values.
+    Delete,
+    /// Hard-update existing values.
+    HardUpdate,
+    /// Hard-delete existing values.
+    HardDelete,
+    /// Modify permissions for other users.
+    ModifyPermissions,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash, Debug)]
+pub enum AccessList {
+    Public(PublicAccessList),
+    Private(PrivateAccessList),
+}
+
+impl From<PrivateAccessList> for AccessList {
+    fn from(list: PrivateAccessList) -> Self {
+        AccessList::Private(list)
+    }
+}
+
+impl From<PublicAccessList> for AccessList {
+    fn from(list: PublicAccessList) -> Self {
+        AccessList::Public(list)
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash, Debug)]
+pub enum UserAccess {
+    Public(PublicUserAccess),
+    Private(PrivateUserAccess),
+}
+
+impl From<PrivateUserAccess> for UserAccess {
+    fn from(access: PrivateUserAccess) -> Self {
+        UserAccess::Private(access)
+    }
+}
+
+impl From<PublicUserAccess> for UserAccess {
+    fn from(access: PublicUserAccess) -> Self {
+        UserAccess::Public(access)
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash, Debug)]
+pub struct PrivateUserAccess {
+    status: BTreeMap<AccessType, bool>,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash, Debug)]
+pub struct PublicUserAccess {
+    status: BTreeMap<AccessType, bool>,
+}
+
+impl PrivateUserAccess {
+    pub fn new(status: BTreeMap<AccessType, bool>) -> Self {
+        PrivateUserAccess { status }
+    }
+
+    pub fn set(&mut self, status: BTreeMap<AccessType, bool>) {
+        self.status = status;
+    }
+
+    pub fn is_allowed(self, access: &AccessType) -> bool {
+        match self.status.get(access) {
+            Some(true) => true,
+            _ => false,
+        }
+    }
+}
+
+impl PublicUserAccess {
+    pub fn new(status: BTreeMap<AccessType, bool>) -> Self {
+        PublicUserAccess { status }
+    }
+
+    pub fn set(&mut self, status: BTreeMap<AccessType, bool>) {
+        self.status = status; // todo: filter out Queries
+    }
+
+    /// Returns `Some(true)` if `access` is allowed and `Some(false)` if it's not.
+    /// `None` means that `User::Anyone` permissions apply.
+    pub fn is_allowed(self, access: &AccessType) -> Option<bool> {
+        match access {
+            AccessType::Read => Some(true), // It's Public data, so it's always allowed to read it.
+            _ => match self.status.get(access) {
+                Some(true) => Some(true),
+                Some(false) => Some(false),
+                None => None,
+            },
+        }
+    }
+}
+
+pub trait AccessListTrait: Clone + Eq + Ord + Hash + Serialize + DeserializeOwned {
+    fn is_allowed(&self, user: &PublicKey, access: &AccessType) -> bool;
+    fn expected_data_version(&self) -> u64;
+    fn expected_owners_version(&self) -> u64;
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash, Debug)]
+pub struct PrivateAccessList {
+    pub access_list: BTreeMap<PublicKey, PrivateUserAccess>,
+    /// The expected index of the data at the time this grant status change is to become valid.
+    pub expected_data_version: u64,
+    /// The expected index of the owners at the time this grant status is to become valid.
+    pub expected_owners_version: u64,
+}
+
+impl PrivateAccessList {
+    pub fn access_list(&self) -> &BTreeMap<PublicKey, PrivateUserAccess> {
+        &self.access_list
+    }
+}
+
+impl AccessListTrait for PrivateAccessList {
+    fn is_allowed(&self, user: &PublicKey, access: &AccessType) -> bool {
+        match self.access_list.get(user) {
+            Some(access_status) => access_status.clone().is_allowed(access),
+            None => false,
+        }
+    }
+
+    fn expected_data_version(&self) -> u64 {
+        self.expected_data_version
+    }
+
+    fn expected_owners_version(&self) -> u64 {
+        self.expected_owners_version
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash, Debug)]
+pub struct PublicAccessList {
+    pub access_list: BTreeMap<User, PublicUserAccess>,
+    /// The expected index of the data at the time this grant status change is to become valid.
+    pub expected_data_version: u64,
+    /// The expected index of the owners at the time this grant status change is to become valid.
+    pub expected_owners_version: u64,
+}
+
+impl PublicAccessList {
+    fn is_allowed_(&self, user: &User, access: &AccessType) -> Option<bool> {
+        match self.access_list.get(user) {
+            Some(status) => match status.clone().is_allowed(access) {
+                Some(true) => Some(true),
+                Some(false) => Some(false),
+                None => None,
+            },
+            _ => None,
+        }
+    }
+
+    pub fn access_list(&self) -> &BTreeMap<User, PublicUserAccess> {
+        &self.access_list
+    }
+}
+
+impl AccessListTrait for PublicAccessList {
+    fn is_allowed(&self, user: &PublicKey, access: &AccessType) -> bool {
+        match self.is_allowed_(&User::Specific(*user), access) {
+            Some(true) => true,
+            Some(false) => false,
+            None => match self.is_allowed_(&User::Anyone, access) {
+                Some(true) => true,
+                _ => false,
+            },
+        }
+    }
+
+    fn expected_data_version(&self) -> u64 {
+        self.expected_data_version
+    }
+
+    fn expected_owners_version(&self) -> u64 {
+        self.expected_owners_version
+    }
+}

--- a/src/authorization/mod.rs
+++ b/src/authorization/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+pub mod access_control;
+mod tests;
+pub use access_control::{
+    AccessList, AccessListTrait, AccessType, PrivateAccessList, PrivateUserAccess,
+    PublicAccessList, PublicUserAccess, UserAccess,
+};

--- a/src/data/map.rs
+++ b/src/data/map.rs
@@ -1,0 +1,1517 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+use crate::authorization::{
+    AccessListTrait, AccessType, PrivateAccessList, PrivateUserAccess, PublicAccessList,
+    PublicUserAccess,
+};
+use crate::shared_types::{
+    to_absolute_range, to_absolute_version, Address, ExpectedVersions, Key, Keys, Kind, KvPair,
+    NonSentried, Owner, Sentried, User, Value, Values, Version,
+};
+use crate::{EntryError, Error, PublicKey, Result, XorName};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{btree_map::Entry, BTreeMap, BTreeSet},
+    fmt::{self, Debug, Formatter},
+    mem,
+};
+
+/// Public Map with concurrency control.
+pub type PublicSentriedMap = MapBase<PublicAccessList, Sentried>;
+/// Public Map.
+pub type PublicMap = MapBase<PublicAccessList, NonSentried>;
+/// Private Map with concurrency control.
+pub type PrivateSentriedMap = MapBase<PrivateAccessList, Sentried>;
+/// Private Map.
+pub type PrivateMap = MapBase<PrivateAccessList, NonSentried>;
+/// All the keys in the map, with all their versions of values.
+pub type DataHistories = BTreeMap<Key, Vec<StoredValue>>;
+/// A vector of data entries.
+pub type DataEntries = Vec<DataEntry>;
+
+/// A representation of a key and its value - current or at some version.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default, Debug)]
+pub struct DataEntry {
+    /// Key
+    pub key: Key,
+    /// Value
+    pub value: Value,
+}
+
+impl DataEntry {
+    /// Returns a new instance of a data entry.
+    pub fn new(key: Key, value: Value) -> Self {
+        Self { key, value }
+    }
+}
+
+///
+#[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash)]
+pub struct MapBase<C, S> {
+    address: Address,
+    data: DataHistories,
+    access_list: Vec<C>,
+    // This is the history of owners, with each entry representing an owner.  Each single owner
+    // could represent an individual user, or a group of users, depending on the `PublicKey` type.
+    owners: Vec<Owner>,
+    /// Version should be increased for any changes to Map data entries,
+    /// but not for permissions and owner changes.
+    version: Option<u64>,
+    _flavour: S,
+}
+
+/// Common methods for all `Map` flavours.
+impl<C, S> MapBase<C, S>
+where
+    C: AccessListTrait,
+    S: Copy,
+{
+    /// Returns true if the provided access type is allowed for the specific user (identified y their public key).
+    pub fn is_allowed(&self, user: PublicKey, access: AccessType) -> bool {
+        match self.owner_at(Version::FromEnd(1)) {
+            Some(owner) => {
+                if owner.public_key == user {
+                    return true;
+                }
+            }
+            None => (),
+        }
+        match self.access_list_at(Version::FromEnd(1)) {
+            Some(access_list) => access_list.is_allowed(&user, &access),
+            None => false,
+        }
+    }
+
+    /// Return the address of this Map.
+    pub fn address(&self) -> &Address {
+        &self.address
+    }
+
+    /// Return the name of this Map.
+    pub fn name(&self) -> &XorName {
+        self.address.name()
+    }
+
+    /// Return the type tag of this Map.
+    pub fn tag(&self) -> u64 {
+        self.address.tag()
+    }
+
+    /// Returns true if the user is the current owner, false if not.
+    pub fn is_owner(&self, user: PublicKey) -> bool {
+        match self.owner_at(Version::FromEnd(1)) {
+            Some(owner) => user == owner.public_key,
+            _ => false,
+        }
+    }
+
+    /// Return the expected data version.
+    pub fn expected_data_version(&self) -> Option<u64> {
+        self.version
+    }
+
+    /// Return the expected owners version.
+    pub fn expected_owners_version(&self) -> u64 {
+        self.owners.len() as u64
+    }
+
+    /// Return the expected access list version.
+    pub fn expected_access_list_version(&self) -> u64 {
+        self.access_list.len() as u64
+    }
+
+    /// Returns expected versions of data, owner and access list.
+    pub fn versions(&self) -> ExpectedVersions {
+        ExpectedVersions::new(
+            self.expected_data_version().unwrap_or_default(),
+            self.expected_owners_version(),
+            self.expected_access_list_version(),
+        )
+    }
+
+    /// Returns the data shell - that is - everything except the entries themselves.
+    pub fn shell(&self, expected_data_version: impl Into<Version>) -> Result<Self> {
+        let expected_data_version = to_absolute_version(
+            expected_data_version.into(),
+            self.expected_data_version().unwrap_or_default() as usize,
+        )
+        .ok_or(Error::NoSuchEntry)? as u64;
+
+        let access_list = self
+            .access_list
+            .iter()
+            .filter(|ac| ac.expected_data_version() <= expected_data_version)
+            .cloned()
+            .collect();
+
+        let owners = self
+            .owners
+            .iter()
+            .filter(|owner| owner.expected_data_version <= expected_data_version)
+            .cloned()
+            .collect();
+
+        Ok(Self {
+            address: self.address,
+            data: BTreeMap::new(),
+            access_list,
+            owners,
+            version: self.version,
+            _flavour: self._flavour,
+        })
+    }
+
+    /// Return a value for the given key (if it is present).
+    pub fn get_value(&self, key: &Key) -> Option<&Value> {
+        match self.data.get(key) {
+            Some(history) => {
+                match history.last() {
+                    Some(StoredValue::Value(value)) => Some(value),
+                    Some(StoredValue::Tombstone()) => None,
+                    None => panic!(
+                        "This is a bug! We are not supposed to have stored None under a key."
+                    ), // should we panic here? Would like to return Error::NetworkOther(String)
+                }
+            }
+            None => None,
+        }
+    }
+
+    /// Return a value for the given key (if it is present).
+    pub fn get_value_at(&self, key: &Key, version: Version) -> Option<&Value> {
+        match self.data.get(key) {
+            Some(history) => {
+                let abs_ver = to_absolute_version(version, history.len())?;
+                match history.get(abs_ver) {
+                    Some(StoredValue::Value(value)) => Some(value),
+                    Some(StoredValue::Tombstone()) => None,
+                    None => panic!(
+                        "This is a bug! We are not supposed to have stored None under a key."
+                    ), // should we panic here? Would like to return Error::NetworkOther(String)
+                }
+            }
+            None => None,
+        }
+    }
+
+    /// Return all values.
+    pub fn get_values(&self) -> Values {
+        self.data
+            .iter()
+            .filter_map(move |(_, values)| match values.last() {
+                Some(StoredValue::Value(val)) => Some(val.to_vec()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Return all data entries.
+    pub fn data_entries(&self) -> DataEntries {
+        self.data
+            .iter()
+            .filter_map(move |(key, values)| match values.last() {
+                Some(StoredValue::Value(val)) => Some(DataEntry {
+                    key: key.clone(),
+                    value: val.to_vec(),
+                }),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Return all keys.
+    pub fn get_keys(&self) -> Keys {
+        self.data
+            .iter()
+            .filter_map(move |(key, values)| match values.last() {
+                Some(StoredValue::Value(_)) => Some(key.to_vec()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Returns history of all keys
+    pub fn key_histories(&self) -> &DataHistories {
+        &self.data
+    }
+
+    /// Returns the history of a specified key.
+    pub fn key_history(&self, key: &Key) -> Option<&StoredValues> {
+        match self.data.get(key) {
+            Some(history) => Some(history),
+            None => None,
+        }
+    }
+
+    /// Returns a range in the history of a specified key.
+    pub fn key_history_range(
+        &self,
+        key: &Key,
+        start: Version,
+        end: Version,
+    ) -> Option<StoredValues> {
+        let range = to_absolute_range(start, end, self.data.len())?;
+        match self.data.get(key) {
+            Some(history) => Some(history[range].to_vec()),
+            None => None,
+        }
+    }
+
+    /// Get owner at version.
+    pub fn owner_at(&self, version: impl Into<Version>) -> Option<&Owner> {
+        let version = to_absolute_version(version.into(), self.owners.len())?;
+        self.owners.get(version)
+    }
+
+    /// Returns history of all owners
+    pub fn owner_history(&self) -> Vec<Owner> {
+        self.owners.clone()
+    }
+
+    /// Get history of owners within the range of versions specified.
+    pub fn owner_history_range(&self, start: Version, end: Version) -> Option<Vec<Owner>> {
+        let range = to_absolute_range(start, end, self.owners.len())?;
+        Some(self.owners[range].iter().map(|c| *c).collect())
+    }
+
+    /// Get access list at version.
+    pub fn access_list_at(&self, version: impl Into<Version>) -> Option<&C> {
+        let version = to_absolute_version(version.into(), self.access_list.len())?;
+        self.access_list.get(version)
+    }
+
+    /// Returns history of all access list states
+    pub fn access_list_history(&self) -> Vec<C> {
+        self.access_list.clone()
+    }
+
+    /// Get history of access list within the range of versions specified.
+    pub fn access_list_history_range(&self, start: Version, end: Version) -> Option<Vec<C>> {
+        let range = to_absolute_range(start, end, self.access_list.len())?;
+        Some(self.access_list[range].iter().map(|c| c.clone()).collect())
+    }
+
+    /// Set owner.
+    pub fn set_owner(&mut self, owner: Owner, version: u64) -> Result<()> {
+        if owner.expected_data_version != self.expected_data_version().unwrap_or_default() {
+            return Err(Error::InvalidSuccessor(
+                self.expected_data_version().unwrap_or_default(),
+            ));
+        }
+        if owner.expected_access_list_version != self.expected_access_list_version() {
+            return Err(Error::InvalidPermissionsSuccessor(
+                self.expected_access_list_version(),
+            ));
+        }
+        if self.expected_owners_version() != version {
+            return Err(Error::InvalidSuccessor(self.expected_owners_version()));
+        }
+        self.owners.push(owner);
+        Ok(())
+    }
+
+    /// Set access list.
+    /// The `AccessList` struct needs to contain the correct expected versions.
+    pub fn set_access_list(&mut self, access_list: &C, version: u64) -> Result<()> {
+        if access_list.expected_data_version() != self.expected_data_version().unwrap_or_default() {
+            return Err(Error::InvalidSuccessor(
+                self.expected_data_version().unwrap_or_default(),
+            ));
+        }
+        if access_list.expected_owners_version() != self.expected_owners_version() {
+            return Err(Error::InvalidOwnersSuccessor(
+                self.expected_owners_version(),
+            ));
+        }
+        if self.expected_access_list_version() != version {
+            return Err(Error::InvalidSuccessor(self.expected_access_list_version()));
+        }
+        self.access_list.push(access_list.clone()); // hmm... do we have to clone in situations like these?
+        Ok(())
+    }
+}
+
+/// Indicates Map mutations that will pass regardless of version.
+#[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Serialize, Deserialize, Debug)]
+pub enum Cmd {
+    /// Inserts a new entry
+    Insert(KvPair),
+    /// Updates an entry with a new value
+    Update(KvPair),
+    /// Deletes an entry
+    Delete(Key),
+}
+
+/// Indicates Map mutations with concurrency control.
+#[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Serialize, Deserialize, Debug)]
+pub enum SentriedCmd {
+    /// Inserts a new entry
+    Insert(SentriedKvPair),
+    /// Updates an entry with a new value
+    Update(SentriedKvPair),
+    /// Deletes an entry
+    Delete(SentriedKey),
+}
+
+/// Indicates whether the transaction can perform permanent deletion or not.
+#[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
+pub enum MapTransaction {
+    /// Only soft deletes possible.
+    Commit(SentryOption),
+    /// Allows hard-deletes.
+    HardCommit(SentryOption),
+}
+
+/// Indicates whether the transaction is carried out with concurrency control or not.
+#[derive(Hash, Eq, PartialEq, PartialOrd, Ord, Clone, Serialize, Deserialize, Debug)]
+pub enum SentryOption {
+    /// No concurrency control.
+    AnyVersion(Transaction),
+    /// Optimistic concurrency.
+    ExpectVersion(SentriedTransaction),
+}
+
+pub type Transaction = Vec<Cmd>;
+
+///
+pub type ExpectedVersion = u64;
+///
+pub type SentriedKey = (Key, ExpectedVersion);
+///
+pub type SentriedKvPair = (KvPair, ExpectedVersion);
+///
+pub type SentriedTransaction = Vec<SentriedCmd>;
+
+/// Common methods for NonSentried flavours.
+impl<P: AccessListTrait> MapBase<P, NonSentried> {
+    /// Commit transaction.
+    ///
+    /// If the specified `expected_version` does not equal the entries count in data, an
+    /// error will be returned.
+    pub fn commit(&mut self, tx: &Transaction) -> Result<()> {
+        // Deconstruct tx into inserts, updates, and deletes
+        let operations: Operations = tx.into_iter().fold(
+            Default::default(),
+            |(mut insert, mut update, mut delete), cmd| {
+                match cmd {
+                    Cmd::Insert(kv_pair) => {
+                        let _ = insert.insert(kv_pair.clone());
+                    }
+                    Cmd::Update(kv_pair) => {
+                        let _ = update.insert(kv_pair.clone());
+                    }
+                    Cmd::Delete(key) => {
+                        let _ = delete.insert(key.clone());
+                    }
+                };
+                (insert, update, delete)
+            },
+        );
+
+        self.apply(operations)
+    }
+
+    fn apply(&mut self, tx: Operations) -> Result<()> {
+        let (insert, update, delete) = tx;
+        if insert.is_empty() && update.is_empty() && delete.is_empty() {
+            return Err(Error::InvalidOperation);
+        }
+        let mut new_data = self.data.clone();
+        let mut errors = BTreeMap::new();
+
+        for (key, val) in insert {
+            match new_data.entry(key) {
+                Entry::Occupied(mut entry) => {
+                    let history = entry.get_mut();
+                    match history.last() {
+                        Some(StoredValue::Value(_)) => {
+                            let _ = errors.insert(
+                                entry.key().clone(),
+                                EntryError::EntryExists(entry.get().len() as u64),
+                            );
+                        }
+                        Some(StoredValue::Tombstone()) => {
+                            let _ = history.push(StoredValue::Value(val));
+                            // todo: fix From impl
+                        }
+                        None => {
+                            let _ = history.push(StoredValue::Value(val));
+                            // todo: fix From impl
+                        }
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    let _ = entry.insert(vec![StoredValue::Value(val)]); // todo: fix From impl
+                }
+            }
+        }
+
+        for (key, val) in update {
+            match new_data.entry(key) {
+                Entry::Occupied(mut entry) => {
+                    let history = entry.get_mut();
+                    match history.last() {
+                        Some(StoredValue::Value(_)) => {
+                            let _ = history.push(StoredValue::Value(val));
+                            // todo: fix From impl
+                        }
+                        Some(StoredValue::Tombstone()) => {
+                            let _ = errors.insert(entry.key().clone(), EntryError::NoSuchEntry);
+                        }
+                        None => panic!("This is a bug! We are not supposed to have stored None."), // should we panic here? Would like to return Error::NetworkOther(String)
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    let _ = errors.insert(entry.key().clone(), EntryError::NoSuchEntry);
+                }
+            }
+        }
+
+        for key in delete {
+            match new_data.entry(key.clone()) {
+                Entry::Occupied(mut entry) => {
+                    let history = entry.get_mut();
+                    match history.last() {
+                        Some(StoredValue::Value(_)) => {
+                            let _ = history.push(StoredValue::Tombstone());
+                        }
+                        Some(StoredValue::Tombstone()) => {
+                            let _ = errors.insert(entry.key().clone(), EntryError::NoSuchEntry);
+                        }
+                        None => panic!("This is a bug! We are not supposed to have stored None."), // should we panic here? Would like to return Error::NetworkOther(String)
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    let _ = errors.insert(entry.key().clone(), EntryError::NoSuchEntry);
+                }
+            }
+        }
+
+        if !errors.is_empty() {
+            return Err(Error::InvalidEntryActions(errors));
+        }
+
+        let _old_data = mem::replace(&mut self.data, new_data);
+        Ok(())
+    }
+}
+
+/// Common methods for Sentried flavours.
+impl<P: AccessListTrait> MapBase<P, Sentried> {
+    /// Commit transaction.
+    ///
+    /// If the specified `expected_version` does not equal the entries count in data, an
+    /// error will be returned.
+    pub fn commit(&mut self, tx: &SentriedTransaction) -> Result<()> {
+        // Deconstruct tx into inserts, updates, and deletes
+        let operations: SentriedOperations = tx.into_iter().fold(
+            Default::default(),
+            |(mut insert, mut update, mut delete), cmd| {
+                match cmd {
+                    SentriedCmd::Insert(sentried_kvpair) => {
+                        let _ = insert.insert(sentried_kvpair.clone());
+                    }
+                    SentriedCmd::Update(sentried_kvpair) => {
+                        let _ = update.insert(sentried_kvpair.clone());
+                    }
+                    SentriedCmd::Delete(sentried_key) => {
+                        let _ = delete.insert(sentried_key.clone());
+                    }
+                };
+                (insert, update, delete)
+            },
+        );
+
+        self.apply(operations)
+    }
+
+    fn apply(&mut self, tx: SentriedOperations) -> Result<()> {
+        let (insert, update, delete) = tx;
+        let op_count = insert.len() + update.len() + delete.len();
+        if op_count == 0 {
+            return Err(Error::InvalidOperation);
+        }
+        let mut new_data = self.data.clone();
+        let mut errors = BTreeMap::new();
+
+        for ((key, val), version) in insert {
+            match new_data.entry(key) {
+                Entry::Occupied(mut entry) => match entry.get().last() {
+                    Some(value) => match value {
+                        StoredValue::Tombstone() => {
+                            let expected_version = entry.get().len() as u64;
+                            if version == expected_version {
+                                let _ = &mut entry.get_mut().push(StoredValue::Value(val));
+                            } else {
+                                let _ = errors.insert(
+                                    entry.key().clone(),
+                                    EntryError::InvalidSuccessor(expected_version),
+                                );
+                            }
+                        }
+                        StoredValue::Value(_) => {
+                            let _ = errors.insert(
+                                entry.key().clone(),
+                                EntryError::EntryExists(entry.get().len() as u64),
+                            );
+                        }
+                    },
+                    None => panic!("This is a bug! We are not supposed to have stored None."), // should we panic here? Would like to return Error::NetworkOther(String)
+                },
+                Entry::Vacant(entry) => {
+                    if version == 0 {
+                        let _ = entry.insert(vec![StoredValue::Value(val)]);
+                    } else {
+                        let _ = errors.insert(entry.key().clone(), EntryError::InvalidSuccessor(0));
+                    }
+                }
+            }
+        }
+
+        for ((key, val), version) in update {
+            match new_data.entry(key) {
+                Entry::Occupied(mut entry) => {
+                    match entry.get().last() {
+                        Some(StoredValue::Value(_)) => {
+                            let history = entry.get_mut();
+                            let expected_version = history.len() as u64;
+                            if version == expected_version {
+                                let _ = history.push(StoredValue::Value(val));
+                            } else {
+                                let _ = errors.insert(
+                                    entry.key().clone(),
+                                    EntryError::InvalidSuccessor(expected_version),
+                                );
+                            }
+                        }
+                        Some(StoredValue::Tombstone()) => {
+                            let _ = errors.insert(entry.key().clone(), EntryError::NoSuchEntry);
+                        }
+                        None => panic!("This is a bug! We are not supposed to have stored None."), // should we panic here? Would like to return Error::NetworkOther(String)
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    let _ = errors.insert(entry.key().clone(), EntryError::NoSuchEntry);
+                }
+            }
+        }
+
+        for (key, version) in delete {
+            match new_data.entry(key.clone()) {
+                Entry::Occupied(mut entry) => {
+                    let history = entry.get_mut();
+                    match history.last() {
+                        Some(StoredValue::Value(_)) => {
+                            let expected_version = history.len() as u64;
+                            if version == expected_version {
+                                let _ = history.push(StoredValue::Tombstone());
+                            } else {
+                                let _ = errors.insert(
+                                    entry.key().clone(),
+                                    EntryError::InvalidSuccessor(expected_version),
+                                );
+                            }
+                        }
+                        Some(StoredValue::Tombstone()) => {
+                            let _ = errors.insert(entry.key().clone(), EntryError::NoSuchEntry);
+                        }
+                        None => panic!("This is a bug! We are not supposed to have stored None."), // should we panic here? Would like to return Error::NetworkOther(String)
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    let _ = errors.insert(entry.key().clone(), EntryError::NoSuchEntry);
+                }
+            }
+        }
+
+        if !errors.is_empty() {
+            return Err(Error::InvalidEntryActions(errors));
+        }
+
+        self.version = Some(self.version.unwrap() + 1);
+        let _old_data = mem::replace(&mut self.data, new_data);
+        Ok(())
+    }
+}
+
+type Operations = (BTreeSet<KvPair>, BTreeSet<KvPair>, BTreeSet<Key>);
+type SentriedOperations = (
+    BTreeSet<SentriedKvPair>,
+    BTreeSet<SentriedKvPair>,
+    BTreeSet<SentriedKey>,
+);
+
+/// A stored value indicates data or deleted data in case of Tombstone variant.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum StoredValue {
+    /// The actual data under a key.
+    Value(Value),
+    /// Represents a deleted current value of a map key.
+    Tombstone(),
+}
+
+/// A vector of stored values.
+pub type StoredValues = Vec<StoredValue>;
+
+/// Public + Sentried
+impl MapBase<PublicAccessList, Sentried> {
+    /// Returns new instance of private MapBase flavour with concurrency control.
+    pub fn new(name: XorName, tag: u64) -> Self {
+        Self {
+            address: Address::PublicSentried { name, tag },
+            data: BTreeMap::new(),
+            access_list: Vec::new(),
+            owners: Vec::new(),
+            version: Some(0),
+            _flavour: Sentried,
+        }
+    }
+}
+
+impl Debug for MapBase<PublicAccessList, Sentried> {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "PublicSentriedMap {:?}", self.name())
+    }
+}
+
+/// Public + NonSentried
+impl MapBase<PublicAccessList, NonSentried> {
+    /// Returns new instance of public MapBase flavour.
+    pub fn new(name: XorName, tag: u64) -> Self {
+        Self {
+            address: Address::Public { name, tag },
+            data: BTreeMap::new(),
+            access_list: Vec::new(),
+            owners: Vec::new(),
+            version: None,
+            _flavour: NonSentried,
+        }
+    }
+}
+
+impl Debug for MapBase<PublicAccessList, NonSentried> {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "PublicMap {:?}", self.name())
+    }
+}
+
+/// Private + Sentried
+impl MapBase<PrivateAccessList, Sentried> {
+    /// Returns new instance of private MapBase flavour with concurrency control.
+    pub fn new(name: XorName, tag: u64) -> Self {
+        Self {
+            address: Address::PrivateSentried { name, tag },
+            data: BTreeMap::new(),
+            access_list: Vec::new(),
+            owners: Vec::new(),
+            version: Some(0),
+            _flavour: Sentried,
+        }
+    }
+
+    /// Commit transaction.
+    ///
+    /// If the specified `expected_version` does not equal the entries count in data, an
+    /// error will be returned.
+    pub fn hard_commit(&mut self, tx: &SentriedTransaction) -> Result<()> {
+        // Deconstruct tx into inserts, updates, and deletes
+        let operations: SentriedOperations = tx.into_iter().fold(
+            Default::default(),
+            |(mut insert, mut update, mut delete), cmd| {
+                match cmd {
+                    SentriedCmd::Insert(sentried_kvpair) => {
+                        let _ = insert.insert(sentried_kvpair.clone());
+                    }
+                    SentriedCmd::Update(sentried_kvpair) => {
+                        let _ = update.insert(sentried_kvpair.clone());
+                    }
+                    SentriedCmd::Delete(sentried_key) => {
+                        let _ = delete.insert(sentried_key.clone());
+                    }
+                };
+                (insert, update, delete)
+            },
+        );
+
+        self.hard_apply(operations)
+    }
+
+    fn hard_apply(&mut self, operations: SentriedOperations) -> Result<()> {
+        let (insert, update, delete) = operations;
+        let op_count = insert.len() + update.len() + delete.len();
+        if op_count == 0 {
+            return Err(Error::InvalidOperation);
+        }
+        let mut new_data = self.data.clone();
+        let mut errors = BTreeMap::new();
+
+        for ((key, val), version) in insert {
+            match new_data.entry(key.clone()) {
+                Entry::Occupied(mut entry) => {
+                    let history = entry.get_mut();
+                    match history.last() {
+                        Some(StoredValue::Value(_)) => {
+                            let _ = errors.insert(
+                                entry.key().clone(),
+                                EntryError::EntryExists(entry.get().len() as u64),
+                            );
+                        }
+                        Some(StoredValue::Tombstone()) => {
+                            if version == history.len() as u64 {
+                                let _ = history.push(StoredValue::Value(val));
+                            } else {
+                                let _ = errors.insert(
+                                    key,
+                                    EntryError::InvalidSuccessor(entry.get().len() as u64), // I assume we are here letting caller know what successor is expected
+                                );
+                            }
+                        }
+                        None => {
+                            panic!("This would be a bug! We are not supposed to store empty vecs!")
+                        }
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    if version == 0 {
+                        // still make sure the val.version == 0
+                        let _ = entry.insert(vec![StoredValue::Value(val)]);
+                    } else {
+                        let _ = errors.insert(
+                            key,
+                            EntryError::InvalidSuccessor(0), // I assume we are here letting caller know what successor is expected
+                        );
+                    }
+                }
+            }
+        }
+
+        // overwrites old data, while also incrementing version
+        for ((key, val), version) in update {
+            match new_data.entry(key) {
+                Entry::Occupied(mut entry) => {
+                    let history = entry.get_mut();
+                    match history.last() {
+                        Some(StoredValue::Value(_)) => {
+                            let expected_version = history.len() as u64;
+                            if version == expected_version {
+                                let _old_value = mem::replace(
+                                    &mut history.last(),
+                                    Some(&StoredValue::Tombstone()),
+                                ); // remove old value, as to properly owerwrite on update, but keep the Version, as to increment history length (i.e. version)
+                                let _ = history.push(StoredValue::Value(val));
+                            } else {
+                                let _ = errors.insert(
+                                    entry.key().clone(),
+                                    EntryError::InvalidSuccessor(expected_version), // I assume we are here letting caller know what successor is expected
+                                );
+                            }
+                        }
+                        Some(StoredValue::Tombstone()) => {
+                            let _ = errors.insert(entry.key().clone(), EntryError::NoSuchEntry);
+                        }
+                        None => {
+                            panic!("This would be a bug! We are not supposed to store empty vecs!")
+                        }
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    let _ = errors.insert(entry.key().clone(), EntryError::NoSuchEntry);
+                }
+            }
+        }
+
+        // removes old data, while also incrementing version
+        for (key, version) in delete {
+            match new_data.entry(key.clone()) {
+                Entry::Occupied(mut entry) => {
+                    let history = entry.get_mut();
+                    match history.last() {
+                        Some(StoredValue::Value(_)) => {
+                            let expected_version = history.len() as u64;
+                            if version == expected_version {
+                                let _old_value = mem::replace(
+                                    &mut history.last(),
+                                    Some(&StoredValue::Tombstone()),
+                                ); // remove old value, as to properly delete, but keep the Version, as to increment history length (i.e. version)
+                                let _ = history.push(StoredValue::Tombstone());
+                            } else {
+                                let _ = errors.insert(
+                                    entry.key().clone(),
+                                    EntryError::InvalidSuccessor(expected_version), // I assume we are here letting caller know what successor is expected
+                                );
+                            }
+                        }
+                        Some(StoredValue::Tombstone()) => {
+                            let _ = errors.insert(entry.key().clone(), EntryError::NoSuchEntry);
+                        }
+                        None => {
+                            panic!("This would be a bug! We are not supposed to store empty vecs!")
+                        }
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    let _ = errors.insert(entry.key().clone(), EntryError::NoSuchEntry);
+                }
+            }
+        }
+
+        if !errors.is_empty() {
+            return Err(Error::InvalidEntryActions(errors));
+        }
+
+        self.version = Some(self.version.unwrap() + 1);
+        let _old_data = mem::replace(&mut self.data, new_data);
+        Ok(())
+    }
+}
+
+impl Debug for MapBase<PrivateAccessList, Sentried> {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "PrivateSentriedMap {:?}", self.name())
+    }
+}
+
+/// Private + NonSentried
+impl MapBase<PrivateAccessList, NonSentried> {
+    /// Returns new instance of private MapBase flavour.
+    pub fn new(name: XorName, tag: u64) -> Self {
+        Self {
+            address: Address::Private { name, tag },
+            data: BTreeMap::new(),
+            access_list: Vec::new(),
+            owners: Vec::new(),
+            version: None,
+            _flavour: NonSentried,
+        }
+    }
+
+    /// Commit transaction that potentially hard deletes data.
+    ///
+    /// If the specified `expected_version` does not equal the entries count in data, an
+    /// error will be returned.
+    pub fn hard_commit(&mut self, tx: &Transaction) -> Result<()> {
+        // Deconstruct tx into inserts, updates, and deletes
+        let operations: Operations = tx.into_iter().fold(
+            Default::default(),
+            |(mut insert, mut update, mut delete), cmd| {
+                match cmd {
+                    Cmd::Insert(kv_pair) => {
+                        let _ = insert.insert(kv_pair.clone());
+                    }
+                    Cmd::Update(kv_pair) => {
+                        let _ = update.insert(kv_pair.clone());
+                    }
+                    Cmd::Delete(key) => {
+                        let _ = delete.insert(key.clone());
+                    }
+                };
+                (insert, update, delete)
+            },
+        );
+
+        self.hard_apply(operations)
+    }
+
+    fn hard_apply(&mut self, operations: Operations) -> Result<()> {
+        let (insert, update, delete) = operations;
+        let op_count = insert.len() + update.len() + delete.len();
+        if op_count == 0 {
+            return Err(Error::InvalidOperation);
+        }
+        let mut new_data = self.data.clone();
+        let mut errors = BTreeMap::new();
+
+        for (key, val) in insert {
+            match new_data.entry(key.clone()) {
+                Entry::Occupied(mut entry) => {
+                    let history = entry.get_mut();
+                    match history.last() {
+                        Some(StoredValue::Value(_)) => {
+                            let _ = errors.insert(
+                                entry.key().clone(),
+                                EntryError::EntryExists(entry.get().len() as u64),
+                            );
+                        }
+                        Some(StoredValue::Tombstone()) => {
+                            let _ = history.push(StoredValue::Value(val));
+                        }
+                        None => {
+                            panic!("This would be a bug! We are not supposed to store empty vecs!")
+                        }
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    let _ = entry.insert(vec![StoredValue::Value(val)]);
+                }
+            }
+        }
+
+        // hard-updates old data
+        for (key, val) in update {
+            match new_data.entry(key) {
+                Entry::Occupied(mut entry) => {
+                    let history = entry.get_mut();
+                    match history.last() {
+                        Some(StoredValue::Value(_)) => {
+                            let _old_value =
+                                mem::replace(&mut history.last(), Some(&StoredValue::Tombstone())); // remove old value, as to properly owerwrite on update, but keep the Version, as to increment history length (i.e. version)
+                            let _ = history.push(StoredValue::Value(val));
+                        }
+                        Some(StoredValue::Tombstone()) => {
+                            let _ = errors.insert(entry.key().clone(), EntryError::NoSuchEntry);
+                        }
+                        None => {
+                            panic!("This would be a bug! We are not supposed to store empty vecs!")
+                        }
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    let _ = errors.insert(entry.key().clone(), EntryError::NoSuchEntry);
+                }
+            }
+        }
+
+        // hard-deletes old data
+        for key in delete {
+            match new_data.entry(key.clone()) {
+                Entry::Occupied(mut entry) => {
+                    let history = entry.get_mut();
+                    match history.last() {
+                        Some(StoredValue::Value(_)) => {
+                            let _old_value =
+                                mem::replace(&mut history.last(), Some(&StoredValue::Tombstone())); // remove old value, as to properly delete, but keep the Version, as to increment history length (i.e. version)
+                            let _ = history.push(StoredValue::Tombstone());
+                        }
+                        Some(StoredValue::Tombstone()) => {
+                            let _ = errors.insert(entry.key().clone(), EntryError::NoSuchEntry);
+                        }
+                        None => {
+                            panic!("This would be a bug! We are not supposed to store empty vecs!")
+                        }
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    let _ = errors.insert(entry.key().clone(), EntryError::NoSuchEntry);
+                }
+            }
+        }
+
+        if !errors.is_empty() {
+            return Err(Error::InvalidEntryActions(errors));
+        }
+
+        let _old_data = mem::replace(&mut self.data, new_data);
+        Ok(())
+    }
+}
+
+impl Debug for MapBase<PrivateAccessList, NonSentried> {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "PrivateMap {:?}", self.name())
+    }
+}
+
+/// Object storing a Map variant.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
+pub enum MapData {
+    /// Public instance with concurrency control.
+    PublicSentried(PublicSentriedMap),
+    /// Public instance.
+    Public(PublicMap),
+    /// Private instance with concurrency control.
+    PrivateSentried(PrivateSentriedMap),
+    /// Private instance.
+    Private(PrivateMap),
+}
+
+impl MapData {
+    /// Returns true if the provided access type is allowed for the specific user (identified y their public key).
+    pub fn is_allowed(&self, access: AccessType, user: PublicKey) -> bool {
+        use AccessType::*;
+        use MapData::*;
+        // Public flavours automatically allows all reads.
+        match (self, access) {
+            (PublicSentried(_), Read) | (Public(_), Read) => return true,
+            _ => (),
+        }
+        match (self, access) {
+            (PublicSentried(data), Insert)
+            | (PublicSentried(data), Update)
+            | (PublicSentried(data), Delete)
+            | (PublicSentried(data), ModifyPermissions) => data.is_allowed(user, access),
+            (Public(data), Insert)
+            | (Public(data), Update)
+            | (Public(data), Delete)
+            | (Public(data), ModifyPermissions) => data.is_allowed(user, access),
+            (PrivateSentried(data), Insert)
+            | (PrivateSentried(data), Update)
+            | (PrivateSentried(data), Delete)
+            | (PrivateSentried(data), HardUpdate)
+            | (PrivateSentried(data), HardDelete)
+            | (PrivateSentried(data), ModifyPermissions) => data.is_allowed(user, access),
+            (Private(data), Insert)
+            | (Private(data), Update)
+            | (Private(data), Delete)
+            | (Private(data), HardUpdate)
+            | (Private(data), HardDelete)
+            | (Private(data), ModifyPermissions) => data.is_allowed(user, access),
+            (PrivateSentried(data), Read) => data.is_allowed(user, access),
+            (Private(data), Read) => data.is_allowed(user, access),
+            _ => false,
+        }
+    }
+
+    /// Returns the address.
+    pub fn address(&self) -> &Address {
+        use MapData::*;
+        match self {
+            PublicSentried(data) => data.address(),
+            Public(data) => data.address(),
+            PrivateSentried(data) => data.address(),
+            Private(data) => data.address(),
+        }
+    }
+
+    /// Returns the kind.
+    pub fn kind(&self) -> Kind {
+        self.address().kind()
+    }
+
+    /// Returns the xor name.
+    pub fn name(&self) -> &XorName {
+        self.address().name()
+    }
+
+    /// Returns the tag type.
+    pub fn tag(&self) -> u64 {
+        self.address().tag()
+    }
+
+    /// Returns true if this instance is public.
+    pub fn is_public(&self) -> bool {
+        self.kind().is_public()
+    }
+
+    /// Returns true if this instance is private.
+    pub fn is_private(&self) -> bool {
+        self.kind().is_private()
+    }
+
+    /// Returns true if this instance employs concurrency control.
+    pub fn is_sentried(&self) -> bool {
+        self.kind().is_sentried()
+    }
+
+    /// Returns true if the provided user (identified by their public key) is the current owner.
+    pub fn is_owner(&self, user: PublicKey) -> bool {
+        use MapData::*;
+        match self {
+            PublicSentried(data) => data.is_owner(user),
+            Public(data) => data.is_owner(user),
+            PrivateSentried(data) => data.is_owner(user),
+            Private(data) => data.is_owner(user),
+        }
+    }
+
+    /// Returns expected version of the instance data.
+    pub fn expected_data_version(&self) -> u64 {
+        use MapData::*;
+        match self {
+            PublicSentried(data) => data.expected_data_version().unwrap_or_default(),
+            Public(data) => data.expected_data_version().unwrap_or_default(),
+            PrivateSentried(data) => data.expected_data_version().unwrap_or_default(),
+            Private(data) => data.expected_data_version().unwrap_or_default(),
+        }
+    }
+
+    /// Returns expected version of the instance access list.
+    pub fn expected_access_list_version(&self) -> u64 {
+        use MapData::*;
+        match self {
+            PublicSentried(data) => data.expected_access_list_version(),
+            Public(data) => data.expected_access_list_version(),
+            PrivateSentried(data) => data.expected_access_list_version(),
+            Private(data) => data.expected_access_list_version(),
+        }
+    }
+
+    /// Returns expected version of the instance owner.
+    pub fn expected_owners_version(&self) -> u64 {
+        use MapData::*;
+        match self {
+            PublicSentried(data) => data.expected_owners_version(),
+            Public(data) => data.expected_owners_version(),
+            PrivateSentried(data) => data.expected_owners_version(),
+            Private(data) => data.expected_owners_version(),
+        }
+    }
+
+    /// Returns expected versions of data, owner and access list.
+    pub fn versions(&self) -> ExpectedVersions {
+        use MapData::*;
+        match self {
+            PublicSentried(data) => data.versions(),
+            Public(data) => data.versions(),
+            PrivateSentried(data) => data.versions(),
+            Private(data) => data.versions(),
+        }
+    }
+
+    /// Returns the value of the key.
+    pub fn get_value(&self, key: &Key) -> Option<&Value> {
+        use MapData::*;
+        match self {
+            PublicSentried(data) => data.get_value(key),
+            Public(data) => data.get_value(key),
+            PrivateSentried(data) => data.get_value(key),
+            Private(data) => data.get_value(key),
+        }
+    }
+
+    /// Returns the value of the key, at a specific version of the key.
+    pub fn get_value_at(&self, key: &Key, version: Version) -> Option<&Value> {
+        use MapData::*;
+        match self {
+            PublicSentried(data) => data.get_value_at(key, version),
+            Public(data) => data.get_value_at(key, version),
+            PrivateSentried(data) => data.get_value_at(key, version),
+            Private(data) => data.get_value_at(key, version),
+        }
+    }
+
+    /// Returns all key value pairs.
+    pub fn data_entries(&self) -> DataEntries {
+        use MapData::*;
+        match self {
+            PublicSentried(data) => data.data_entries(),
+            Public(data) => data.data_entries(),
+            PrivateSentried(data) => data.data_entries(),
+            Private(data) => data.data_entries(),
+        }
+    }
+
+    /// Returns all values.
+    pub fn get_values(&self) -> Values {
+        use MapData::*;
+        match self {
+            PublicSentried(data) => data.get_values(),
+            Public(data) => data.get_values(),
+            PrivateSentried(data) => data.get_values(),
+            Private(data) => data.get_values(),
+        }
+    }
+
+    /// Returns all keys.
+    pub fn get_keys(&self) -> Keys {
+        use MapData::*;
+        match self {
+            PublicSentried(data) => data.get_keys(),
+            Public(data) => data.get_keys(),
+            PrivateSentried(data) => data.get_keys(),
+            Private(data) => data.get_keys(),
+        }
+    }
+
+    /// Returns the history of a specified key.
+    pub fn key_history(&self, key: &Key) -> Option<&StoredValues> {
+        use MapData::*;
+        match self {
+            PublicSentried(data) => data.key_history(key),
+            Public(data) => data.key_history(key),
+            PrivateSentried(data) => data.key_history(key),
+            Private(data) => data.key_history(key),
+        }
+    }
+
+    /// Returns a range in the history of a specified key.
+    pub fn key_history_range(&self, key: &Key, from: Version, to: Version) -> Option<StoredValues> {
+        use MapData::*;
+        match self {
+            PublicSentried(data) => data.key_history_range(key, from, to),
+            Public(data) => data.key_history_range(key, from, to),
+            PrivateSentried(data) => data.key_history_range(key, from, to),
+            Private(data) => data.key_history_range(key, from, to),
+        }
+    }
+
+    /// Returns history for all keys
+    pub fn key_histories(&self) -> &DataHistories {
+        use MapData::*;
+        match self {
+            PublicSentried(data) => data.key_histories(),
+            Public(data) => data.key_histories(),
+            PrivateSentried(data) => data.key_histories(),
+            Private(data) => data.key_histories(),
+        }
+    }
+
+    /// Returns the owner at a specific version of owners.
+    pub fn owner_at(&self, version: impl Into<Version>) -> Option<&Owner> {
+        use MapData::*;
+        match self {
+            PublicSentried(data) => data.owner_at(version),
+            Public(data) => data.owner_at(version),
+            PrivateSentried(data) => data.owner_at(version),
+            Private(data) => data.owner_at(version),
+        }
+    }
+
+    /// Returns history of all owners
+    pub fn owner_history(&self) -> Result<Vec<Owner>> {
+        use MapData::*;
+        let result = match self {
+            PublicSentried(data) => Some(data.owner_history()),
+            Public(data) => Some(data.owner_history()),
+            PrivateSentried(data) => Some(data.owner_history()),
+            Private(data) => Some(data.owner_history()),
+        };
+        result.ok_or(Error::NoSuchEntry)
+    }
+
+    /// Get history of owners within the range of versions specified.
+    pub fn owner_history_range(&self, start: Version, end: Version) -> Result<Vec<Owner>> {
+        use MapData::*;
+        let result = match self {
+            PublicSentried(data) => data.owner_history_range(start, end),
+            Public(data) => data.owner_history_range(start, end),
+            PrivateSentried(data) => data.owner_history_range(start, end),
+            Private(data) => data.owner_history_range(start, end),
+        };
+        result.ok_or(Error::NoSuchEntry)
+    }
+
+    /// Returns a specific user's access list of a public instance at a specific version.
+    pub fn public_user_access_at(
+        &self,
+        user: User,
+        version: impl Into<Version>,
+    ) -> Result<PublicUserAccess> {
+        self.public_access_list_at(version)?
+            .access_list()
+            .get(&user)
+            .cloned()
+            .ok_or(Error::NoSuchEntry)
+    }
+
+    /// Returns a specific user's access list of a private instance at a specific version.
+    pub fn private_user_access_at(
+        &self,
+        user: PublicKey,
+        version: impl Into<Version>,
+    ) -> Result<PrivateUserAccess> {
+        self.private_access_list_at(version)?
+            .access_list()
+            .get(&user)
+            .cloned()
+            .ok_or(Error::NoSuchEntry)
+    }
+
+    /// Returns the access list of a public instance at a specific version.
+    pub fn public_access_list_at(&self, version: impl Into<Version>) -> Result<&PublicAccessList> {
+        use MapData::*;
+        let access_list = match self {
+            PublicSentried(data) => data.access_list_at(version),
+            Public(data) => data.access_list_at(version),
+            _ => return Err(Error::InvalidOperation),
+        };
+        access_list.ok_or(Error::NoSuchEntry)
+    }
+
+    /// Returns the access list of a private instance at a specific version.
+    pub fn private_access_list_at(
+        &self,
+        version: impl Into<Version>,
+    ) -> Result<&PrivateAccessList> {
+        use MapData::*;
+        let access_list = match self {
+            PrivateSentried(data) => data.access_list_at(version),
+            Private(data) => data.access_list_at(version),
+            _ => return Err(Error::InvalidOperation),
+        };
+        access_list.ok_or(Error::NoSuchEntry)
+    }
+
+    /// Returns history of all access list states
+    pub fn public_access_list_history(&self) -> Result<Vec<PublicAccessList>> {
+        use MapData::*;
+        let result = match self {
+            PublicSentried(data) => Some(data.access_list_history()),
+            Public(data) => Some(data.access_list_history()),
+            _ => return Err(Error::InvalidOperation),
+        };
+        result.ok_or(Error::NoSuchEntry)
+    }
+
+    /// Returns history of all access list states
+    pub fn private_access_list_history(&self) -> Result<Vec<PrivateAccessList>> {
+        use MapData::*;
+        let result = match self {
+            PrivateSentried(data) => Some(data.access_list_history()),
+            Private(data) => Some(data.access_list_history()),
+            _ => return Err(Error::InvalidOperation),
+        };
+        result.ok_or(Error::NoSuchEntry)
+    }
+
+    /// Get history of access list within the range of versions specified.
+    pub fn public_access_list_history_range(
+        &self,
+        start: Version,
+        end: Version,
+    ) -> Result<Vec<PublicAccessList>> {
+        use MapData::*;
+        let result = match self {
+            PublicSentried(data) => data.access_list_history_range(start, end),
+            Public(data) => data.access_list_history_range(start, end),
+            _ => return Err(Error::InvalidOperation),
+        };
+        result.ok_or(Error::NoSuchEntry)
+    }
+
+    /// Get history of access list within the range of versions specified.
+    pub fn private_access_list_history_range(
+        &self,
+        start: Version,
+        end: Version,
+    ) -> Result<Vec<PrivateAccessList>> {
+        use MapData::*;
+        let result = match self {
+            PrivateSentried(data) => data.access_list_history_range(start, end),
+            Private(data) => data.access_list_history_range(start, end),
+            _ => return Err(Error::InvalidOperation),
+        };
+        result.ok_or(Error::NoSuchEntry)
+    }
+
+    /// Returns a shell without the data of the instance, as of a specific data version.
+    pub fn shell(&self, version: impl Into<Version>) -> Result<Self> {
+        use MapData::*;
+        match self {
+            PublicSentried(map) => map.shell(version).map(PublicSentried),
+            Public(map) => map.shell(version).map(Public),
+            PrivateSentried(map) => map.shell(version).map(PrivateSentried),
+            Private(map) => map.shell(version).map(Private),
+        }
+    }
+
+    /// Sets a new owner.
+    pub fn set_owner(&mut self, owner: Owner, expected_version: u64) -> Result<()> {
+        use MapData::*;
+        match self {
+            PublicSentried(adata) => adata.set_owner(owner, expected_version),
+            Public(adata) => adata.set_owner(owner, expected_version),
+            PrivateSentried(adata) => adata.set_owner(owner, expected_version),
+            Private(adata) => adata.set_owner(owner, expected_version),
+        }
+    }
+
+    /// Sets a new access list of a private instance.
+    pub fn set_private_access_list(
+        &mut self,
+        access_list: &PrivateAccessList,
+        expected_version: u64,
+    ) -> Result<()> {
+        use MapData::*;
+        match self {
+            Private(data) => data.set_access_list(access_list, expected_version),
+            PrivateSentried(data) => data.set_access_list(access_list, expected_version),
+            _ => Err(Error::InvalidOperation),
+        }
+    }
+
+    /// Sets a new access list of a public instance.
+    pub fn set_public_access_list(
+        &mut self,
+        access_list: &PublicAccessList,
+        expected_version: u64,
+    ) -> Result<()> {
+        use MapData::*;
+        match self {
+            Public(data) => data.set_access_list(access_list, expected_version),
+            PublicSentried(data) => data.set_access_list(access_list, expected_version),
+            _ => Err(Error::InvalidOperation),
+        }
+    }
+
+    /// Commits transaction.
+    pub fn commit(&mut self, tx: &MapTransaction) -> Result<()> {
+        use MapData::*;
+        use MapTransaction::*;
+        use SentryOption::*;
+        match self {
+            PrivateSentried(map) => match tx {
+                Commit(options) => {
+                    if let ExpectVersion(stx) = options {
+                        return map.commit(stx);
+                    }
+                }
+                HardCommit(options) => {
+                    if let ExpectVersion(stx) = options {
+                        return map.hard_commit(stx);
+                    }
+                }
+            },
+            Private(map) => match tx {
+                Commit(options) => {
+                    if let AnyVersion(tx) = options {
+                        return map.commit(tx);
+                    }
+                }
+                HardCommit(options) => {
+                    if let AnyVersion(tx) = options {
+                        return map.hard_commit(tx);
+                    }
+                }
+            },
+            PublicSentried(map) => match tx {
+                Commit(options) => {
+                    if let ExpectVersion(stx) = options {
+                        return map.commit(stx);
+                    }
+                }
+                _ => return Err(Error::InvalidOperation),
+            },
+            Public(map) => match tx {
+                Commit(options) => {
+                    if let AnyVersion(tx) = options {
+                        return map.commit(tx);
+                    }
+                }
+                _ => return Err(Error::InvalidOperation),
+            },
+        }
+
+        Err(Error::InvalidOperation)
+    }
+}
+
+impl From<PublicSentriedMap> for MapData {
+    fn from(data: PublicSentriedMap) -> Self {
+        MapData::PublicSentried(data)
+    }
+}
+
+impl From<PublicMap> for MapData {
+    fn from(data: PublicMap) -> Self {
+        MapData::Public(data)
+    }
+}
+
+impl From<PrivateSentriedMap> for MapData {
+    fn from(data: PrivateSentriedMap) -> Self {
+        MapData::PrivateSentried(data)
+    }
+}
+
+impl From<PrivateMap> for MapData {
+    fn from(data: PrivateMap) -> Self {
+        MapData::Private(data)
+    }
+}

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -7,8 +7,11 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-pub mod access_control;
-pub use access_control::{
-    AccessList, AccessListTrait, AccessType, PrivateAccessList, PrivateUserAccess,
-    PublicAccessList, PublicUserAccess, UserAccess,
+pub mod map;
+mod tests;
+pub use map::{
+    Cmd as MapCmd, DataEntries as MapEntries, DataHistories as MapKeyHistories, MapData,
+    MapTransaction, PrivateMap, PrivateSentriedMap, PublicMap, PublicSentriedMap,
+    SentriedCmd as SentriedMapCmd, SentryOption, StoredValue as MapValue,
+    StoredValues as MapValues,
 };

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -8,6 +8,7 @@
 // Software.
 
 pub mod map;
+#[cfg(test)]
 mod tests;
 pub use map::{
     Cmd as MapCmd, DataEntries as MapEntries, DataHistories as MapKeyHistories, MapData,

--- a/src/data/tests.rs
+++ b/src/data/tests.rs
@@ -18,28 +18,28 @@ fn insert() {
     let insert_1 = SentriedMapCmd::Insert(((vec![1].into(), vec![0]), 0));
     let insert_2 = SentriedMapCmd::Insert(((vec![2].into(), vec![0]), 0));
     let tx = vec![insert_0, insert_1, insert_2];
-    unwrap!(data.commit(&tx));
+    unwrap!(data.commit(&tx.into()));
 
     let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
     let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
     let insert_1 = SentriedMapCmd::Insert(((vec![1].into(), vec![0]), 0));
     let insert_2 = SentriedMapCmd::Insert(((vec![2].into(), vec![0]), 0));
     let tx = vec![insert_0, insert_1, insert_2];
-    unwrap!(data.commit(&tx));
+    unwrap!(data.commit(&tx.into()));
 
     let mut data = PublicMap::new(XorName([1; 32]), 10000);
     let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
     let insert_1 = MapCmd::Insert((vec![1].into(), vec![0]));
     let insert_2 = MapCmd::Insert((vec![2].into(), vec![0]));
     let tx = vec![insert_0, insert_1, insert_2];
-    unwrap!(data.commit(&tx));
+    unwrap!(data.commit(&tx.into()));
 
     let mut data = PrivateMap::new(XorName([1; 32]), 10000);
     let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
     let insert_1 = MapCmd::Insert((vec![1].into(), vec![0]));
     let insert_2 = MapCmd::Insert((vec![2].into(), vec![0]));
     let tx = vec![insert_0, insert_1, insert_2];
-    unwrap!(data.commit(&tx))
+    unwrap!(data.commit(&tx.into()))
 }
 
 #[test]
@@ -49,28 +49,28 @@ fn update() {
     let update_1 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 1));
     let update_2 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 2));
     let tx = vec![insert_0, update_1, update_2];
-    unwrap!(data.commit(&tx));
+    unwrap!(data.commit(&tx.into()));
 
     let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
     let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
     let update_1 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 1));
     let update_2 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 2));
     let tx = vec![insert_0, update_1, update_2];
-    unwrap!(data.commit(&tx));
+    unwrap!(data.commit(&tx.into()));
 
     let mut data = PublicMap::new(XorName([1; 32]), 10000);
     let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
     let update_1 = MapCmd::Update((vec![0].into(), vec![0]));
     let update_2 = MapCmd::Update((vec![0].into(), vec![0]));
     let tx = vec![insert_0, update_1, update_2];
-    unwrap!(data.commit(&tx));
+    unwrap!(data.commit(&tx.into()));
 
     let mut data = PrivateMap::new(XorName([1; 32]), 10000);
     let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
     let update_1 = MapCmd::Update((vec![0].into(), vec![0]));
     let update_2 = MapCmd::Update((vec![0].into(), vec![0]));
     let tx = vec![insert_0, update_1, update_2];
-    unwrap!(data.commit(&tx))
+    unwrap!(data.commit(&tx.into()))
 }
 
 #[test]
@@ -80,28 +80,28 @@ fn delete() {
     let update_1 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 1));
     let delete_2 = SentriedMapCmd::Delete((vec![0].into(), 2));
     let tx = vec![insert_0, update_1, delete_2];
-    unwrap!(data.commit(&tx));
+    unwrap!(data.commit(&tx.into()));
 
     let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
     let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
     let update_1 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 1));
     let delete_2 = SentriedMapCmd::Delete((vec![0].into(), 2));
     let tx = vec![insert_0, update_1, delete_2];
-    unwrap!(data.commit(&tx));
+    unwrap!(data.commit(&tx.into()));
 
     let mut data = PublicMap::new(XorName([1; 32]), 10000);
     let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
     let update_1 = MapCmd::Update((vec![0].into(), vec![0]));
     let delete_2 = MapCmd::Delete(vec![0].into());
     let tx = vec![insert_0, update_1, delete_2];
-    unwrap!(data.commit(&tx));
+    unwrap!(data.commit(&tx.into()));
 
     let mut data = PrivateMap::new(XorName([1; 32]), 10000);
     let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
     let update_1 = MapCmd::Update((vec![0].into(), vec![0]));
     let delete_2 = MapCmd::Delete(vec![0].into());
     let tx = vec![insert_0, update_1, delete_2];
-    unwrap!(data.commit(&tx))
+    unwrap!(data.commit(&tx.into()))
 }
 
 #[test]
@@ -111,40 +111,40 @@ fn re_insert() {
     let update_1 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 1));
     let delete_2 = SentriedMapCmd::Delete((vec![0].into(), 2));
     let tx_0 = vec![insert_0, update_1, delete_2];
-    unwrap!(data.commit(&tx_0));
+    unwrap!(data.commit(&tx_0.into()));
     let insert_3 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 3));
     let tx_1 = vec![insert_3];
-    unwrap!(data.commit(&tx_1));
+    unwrap!(data.commit(&tx_1.into()));
 
     let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
     let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
     let update_1 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 1));
     let delete_2 = SentriedMapCmd::Delete((vec![0].into(), 2));
     let tx_0 = vec![insert_0, update_1, delete_2];
-    unwrap!(data.commit(&tx_0));
+    unwrap!(data.commit(&tx_0.into()));
     let insert_3 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 3));
     let tx_1 = vec![insert_3];
-    unwrap!(data.commit(&tx_1));
+    unwrap!(data.commit(&tx_1.into()));
 
     let mut data = PublicMap::new(XorName([1; 32]), 10000);
     let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
     let update_1 = MapCmd::Update((vec![0].into(), vec![0]));
     let delete_2 = MapCmd::Delete(vec![0].into());
     let tx_0 = vec![insert_0, update_1, delete_2];
-    unwrap!(data.commit(&tx_0));
+    unwrap!(data.commit(&tx_0.into()));
     let insert_3 = MapCmd::Insert((vec![0].into(), vec![0]));
     let tx_1 = vec![insert_3];
-    unwrap!(data.commit(&tx_1));
+    unwrap!(data.commit(&tx_1.into()));
 
     let mut data = PrivateMap::new(XorName([1; 32]), 10000);
     let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
     let update_1 = MapCmd::Update((vec![0].into(), vec![0]));
     let delete_2 = MapCmd::Delete(vec![0].into());
     let tx_0 = vec![insert_0, update_1, delete_2];
-    unwrap!(data.commit(&tx_0));
+    unwrap!(data.commit(&tx_0.into()));
     let insert_3 = MapCmd::Insert((vec![0].into(), vec![0]));
     let tx_1 = vec![insert_3];
-    unwrap!(data.commit(&tx_1));
+    unwrap!(data.commit(&tx_1.into()));
 }
 
 #[test]
@@ -152,10 +152,10 @@ fn insert_when_exists_fails() {
     let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
     let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
     let tx = vec![insert_0];
-    unwrap!(data.commit(&tx));
+    unwrap!(data.commit(&tx.into()));
     let insert_1 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
     let tx = vec![insert_1];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::EntryExists(1), *error),
             _ => panic!(),
@@ -166,10 +166,10 @@ fn insert_when_exists_fails() {
     let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
     let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
     let tx = vec![insert_0];
-    unwrap!(data.commit(&tx));
+    unwrap!(data.commit(&tx.into()));
     let insert_1 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
     let tx = vec![insert_1];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::EntryExists(1), *error),
             _ => panic!(),
@@ -180,10 +180,10 @@ fn insert_when_exists_fails() {
     let mut data = PublicMap::new(XorName([1; 32]), 10000);
     let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
     let tx = vec![insert_0];
-    unwrap!(data.commit(&tx));
+    unwrap!(data.commit(&tx.into()));
     let insert_1 = MapCmd::Insert((vec![0].into(), vec![0]));
     let tx = vec![insert_1];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::EntryExists(1), *error),
             _ => panic!(),
@@ -194,10 +194,10 @@ fn insert_when_exists_fails() {
     let mut data = PrivateMap::new(XorName([1; 32]), 10000);
     let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
     let tx = vec![insert_0];
-    unwrap!(data.commit(&tx));
+    unwrap!(data.commit(&tx.into()));
     let insert_1 = MapCmd::Insert((vec![0].into(), vec![0]));
     let tx = vec![insert_1];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::EntryExists(1), *error),
             _ => panic!(),
@@ -213,7 +213,7 @@ fn update_with_wrong_version_fails() {
     let update_1 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 1));
     let update_2 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 3)); // <-- wrong version
     let tx = vec![insert_0, update_1, update_2];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::InvalidSuccessor(2), *error),
             _ => panic!(),
@@ -226,7 +226,7 @@ fn update_with_wrong_version_fails() {
     let update_1 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 1));
     let update_2 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 3)); // <-- wrong version
     let tx = vec![insert_0, update_1, update_2];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::InvalidSuccessor(2), *error),
             _ => panic!(),
@@ -241,7 +241,7 @@ fn delete_with_wrong_version_fails() {
     let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
     let delete_1 = SentriedMapCmd::Delete((vec![0].into(), 3)); // <-- wrong version
     let tx = vec![insert_0, delete_1];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::InvalidSuccessor(1), *error),
             _ => panic!(),
@@ -253,7 +253,7 @@ fn delete_with_wrong_version_fails() {
     let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
     let delete_1 = SentriedMapCmd::Delete((vec![0].into(), 3)); // <-- wrong version
     let tx = vec![insert_0, delete_1];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::InvalidSuccessor(1), *error),
             _ => panic!(),
@@ -269,10 +269,10 @@ fn re_insert_with_wrong_version_fails() {
     let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
     let delete_1 = SentriedMapCmd::Delete((vec![0].into(), 1));
     let tx = vec![insert_0, delete_1];
-    unwrap!(data.commit(&tx));
+    unwrap!(data.commit(&tx.into()));
     let insert_2 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 3)); // <-- wrong version
     let tx = vec![insert_2];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::InvalidSuccessor(2), *error),
             _ => panic!(),
@@ -285,10 +285,10 @@ fn re_insert_with_wrong_version_fails() {
     let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
     let delete_1 = SentriedMapCmd::Delete((vec![0].into(), 1));
     let tx = vec![insert_0, delete_1];
-    unwrap!(data.commit(&tx));
+    unwrap!(data.commit(&tx.into()));
     let insert_2 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 3)); // <-- wrong version
     let tx = vec![insert_2];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::InvalidSuccessor(2), *error),
             _ => panic!(),
@@ -303,7 +303,7 @@ fn delete_or_update_nonexisting_fails() {
     // Delete
     let delete_2 = SentriedMapCmd::Delete((vec![0].into(), 2));
     let tx = vec![delete_2];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
             _ => panic!(),
@@ -313,7 +313,7 @@ fn delete_or_update_nonexisting_fails() {
     // Update
     let update_3 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 3));
     let tx = vec![update_3];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
             _ => panic!(),
@@ -326,7 +326,7 @@ fn delete_or_update_nonexisting_fails() {
     // Delete
     let delete_2 = SentriedMapCmd::Delete((vec![0].into(), 2));
     let tx = vec![delete_2];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
             _ => panic!(),
@@ -336,7 +336,7 @@ fn delete_or_update_nonexisting_fails() {
     // Update
     let update_3 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 3));
     let tx = vec![update_3];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
             _ => panic!(),
@@ -349,7 +349,7 @@ fn delete_or_update_nonexisting_fails() {
     // Delete
     let delete_2 = MapCmd::Delete(vec![0].into());
     let tx = vec![delete_2];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
             _ => panic!(),
@@ -359,7 +359,7 @@ fn delete_or_update_nonexisting_fails() {
     // Update
     let update_3 = MapCmd::Update((vec![0].into(), vec![0]));
     let tx = vec![update_3];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
             _ => panic!(),
@@ -372,7 +372,7 @@ fn delete_or_update_nonexisting_fails() {
     // Delete
     let delete_2 = MapCmd::Delete(vec![0].into());
     let tx = vec![delete_2];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
             _ => panic!(),
@@ -382,7 +382,7 @@ fn delete_or_update_nonexisting_fails() {
     // Update
     let update_3 = MapCmd::Update((vec![0].into(), vec![0]));
     let tx = vec![update_3];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
             _ => panic!(),
@@ -398,11 +398,11 @@ fn delete_or_update_deleted_fails() {
     let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
     let delete_1 = SentriedMapCmd::Delete((vec![0].into(), 1));
     let tx = vec![insert_0, delete_1];
-    unwrap!(data.commit(&tx));
+    unwrap!(data.commit(&tx.into()));
     // Delete
     let delete_2 = SentriedMapCmd::Delete((vec![0].into(), 2));
     let tx = vec![delete_2];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
             _ => panic!(),
@@ -412,7 +412,7 @@ fn delete_or_update_deleted_fails() {
     // Update
     let update_3 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 3));
     let tx = vec![update_3];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
             _ => panic!(),
@@ -425,11 +425,11 @@ fn delete_or_update_deleted_fails() {
     let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
     let delete_1 = SentriedMapCmd::Delete((vec![0].into(), 1));
     let tx = vec![insert_0, delete_1];
-    unwrap!(data.commit(&tx));
+    unwrap!(data.commit(&tx.into()));
     // Delete
     let delete_2 = SentriedMapCmd::Delete((vec![0].into(), 2));
     let tx = vec![delete_2];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
             _ => panic!(),
@@ -439,7 +439,7 @@ fn delete_or_update_deleted_fails() {
     // Update
     let update_3 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 3));
     let tx = vec![update_3];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
             _ => panic!(),
@@ -452,11 +452,11 @@ fn delete_or_update_deleted_fails() {
     let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
     let delete_1 = MapCmd::Delete(vec![0].into());
     let tx = vec![insert_0, delete_1];
-    unwrap!(data.commit(&tx));
+    unwrap!(data.commit(&tx.into()));
     // Delete
     let delete_2 = MapCmd::Delete(vec![0].into());
     let tx = vec![delete_2];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
             _ => panic!(),
@@ -466,7 +466,7 @@ fn delete_or_update_deleted_fails() {
     // Update
     let update_3 = MapCmd::Update((vec![0].into(), vec![0]));
     let tx = vec![update_3];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
             _ => panic!(),
@@ -479,11 +479,11 @@ fn delete_or_update_deleted_fails() {
     let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
     let delete_1 = MapCmd::Delete(vec![0].into());
     let tx = vec![insert_0, delete_1];
-    unwrap!(data.commit(&tx));
+    unwrap!(data.commit(&tx.into()));
     // Delete
     let delete_2 = MapCmd::Delete(vec![0].into());
     let tx = vec![delete_2];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
             _ => panic!(),
@@ -493,7 +493,7 @@ fn delete_or_update_deleted_fails() {
     // Update
     let update_3 = MapCmd::Update((vec![0].into(), vec![0]));
     let tx = vec![update_3];
-    match unwrap_err!(data.commit(&tx)) {
+    match unwrap_err!(data.commit(&tx.into())) {
         Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
             Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
             _ => panic!(),

--- a/src/data/tests.rs
+++ b/src/data/tests.rs
@@ -1,0 +1,507 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+#[cfg(test)]
+mod tests {
+    use crate::data::map::*;
+    use crate::data::*;
+    use crate::{EntryError, Error, XorName};
+    use unwrap::{unwrap, unwrap_err};
+
+    #[test]
+    fn insert() {
+        let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
+        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
+        let insert_1 = SentriedMapCmd::Insert(((vec![1], vec![0]), 0));
+        let insert_2 = SentriedMapCmd::Insert(((vec![2], vec![0]), 0));
+        let tx = vec![insert_0, insert_1, insert_2];
+        unwrap!(data.commit(&tx));
+
+        let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
+        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
+        let insert_1 = SentriedMapCmd::Insert(((vec![1], vec![0]), 0));
+        let insert_2 = SentriedMapCmd::Insert(((vec![2], vec![0]), 0));
+        let tx = vec![insert_0, insert_1, insert_2];
+        unwrap!(data.commit(&tx));
+
+        let mut data = PublicMap::new(XorName([1; 32]), 10000);
+        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
+        let insert_1 = MapCmd::Insert((vec![1], vec![0]));
+        let insert_2 = MapCmd::Insert((vec![2], vec![0]));
+        let tx = vec![insert_0, insert_1, insert_2];
+        unwrap!(data.commit(&tx));
+
+        let mut data = PrivateMap::new(XorName([1; 32]), 10000);
+        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
+        let insert_1 = MapCmd::Insert((vec![1], vec![0]));
+        let insert_2 = MapCmd::Insert((vec![2], vec![0]));
+        let tx = vec![insert_0, insert_1, insert_2];
+        unwrap!(data.commit(&tx))
+    }
+
+    #[test]
+    fn update() {
+        let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
+        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
+        let update_1 = SentriedMapCmd::Update(((vec![0], vec![0]), 1));
+        let update_2 = SentriedMapCmd::Update(((vec![0], vec![0]), 2));
+        let tx = vec![insert_0, update_1, update_2];
+        unwrap!(data.commit(&tx));
+
+        let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
+        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
+        let update_1 = SentriedMapCmd::Update(((vec![0], vec![0]), 1));
+        let update_2 = SentriedMapCmd::Update(((vec![0], vec![0]), 2));
+        let tx = vec![insert_0, update_1, update_2];
+        unwrap!(data.commit(&tx));
+
+        let mut data = PublicMap::new(XorName([1; 32]), 10000);
+        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
+        let update_1 = MapCmd::Update((vec![0], vec![0]));
+        let update_2 = MapCmd::Update((vec![0], vec![0]));
+        let tx = vec![insert_0, update_1, update_2];
+        unwrap!(data.commit(&tx));
+
+        let mut data = PrivateMap::new(XorName([1; 32]), 10000);
+        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
+        let update_1 = MapCmd::Update((vec![0], vec![0]));
+        let update_2 = MapCmd::Update((vec![0], vec![0]));
+        let tx = vec![insert_0, update_1, update_2];
+        unwrap!(data.commit(&tx))
+    }
+
+    #[test]
+    fn delete() {
+        let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
+        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
+        let update_1 = SentriedMapCmd::Update(((vec![0], vec![0]), 1));
+        let delete_2 = SentriedMapCmd::Delete((vec![0], 2));
+        let tx = vec![insert_0, update_1, delete_2];
+        unwrap!(data.commit(&tx));
+
+        let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
+        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
+        let update_1 = SentriedMapCmd::Update(((vec![0], vec![0]), 1));
+        let delete_2 = SentriedMapCmd::Delete((vec![0], 2));
+        let tx = vec![insert_0, update_1, delete_2];
+        unwrap!(data.commit(&tx));
+
+        let mut data = PublicMap::new(XorName([1; 32]), 10000);
+        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
+        let update_1 = MapCmd::Update((vec![0], vec![0]));
+        let delete_2 = MapCmd::Delete(vec![0]);
+        let tx = vec![insert_0, update_1, delete_2];
+        unwrap!(data.commit(&tx));
+
+        let mut data = PrivateMap::new(XorName([1; 32]), 10000);
+        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
+        let update_1 = MapCmd::Update((vec![0], vec![0]));
+        let delete_2 = MapCmd::Delete(vec![0]);
+        let tx = vec![insert_0, update_1, delete_2];
+        unwrap!(data.commit(&tx))
+    }
+
+    #[test]
+    fn re_insert() {
+        let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
+        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
+        let update_1 = SentriedMapCmd::Update(((vec![0], vec![0]), 1));
+        let delete_2 = SentriedMapCmd::Delete((vec![0], 2));
+        let tx_0 = vec![insert_0, update_1, delete_2];
+        unwrap!(data.commit(&tx_0));
+        let insert_3 = SentriedMapCmd::Insert(((vec![0], vec![0]), 3));
+        let tx_1 = vec![insert_3];
+        unwrap!(data.commit(&tx_1));
+
+        let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
+        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
+        let update_1 = SentriedMapCmd::Update(((vec![0], vec![0]), 1));
+        let delete_2 = SentriedMapCmd::Delete((vec![0], 2));
+        let tx_0 = vec![insert_0, update_1, delete_2];
+        unwrap!(data.commit(&tx_0));
+        let insert_3 = SentriedMapCmd::Insert(((vec![0], vec![0]), 3));
+        let tx_1 = vec![insert_3];
+        unwrap!(data.commit(&tx_1));
+
+        let mut data = PublicMap::new(XorName([1; 32]), 10000);
+        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
+        let update_1 = MapCmd::Update((vec![0], vec![0]));
+        let delete_2 = MapCmd::Delete(vec![0]);
+        let tx_0 = vec![insert_0, update_1, delete_2];
+        unwrap!(data.commit(&tx_0));
+        let insert_3 = MapCmd::Insert((vec![0], vec![0]));
+        let tx_1 = vec![insert_3];
+        unwrap!(data.commit(&tx_1));
+
+        let mut data = PrivateMap::new(XorName([1; 32]), 10000);
+        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
+        let update_1 = MapCmd::Update((vec![0], vec![0]));
+        let delete_2 = MapCmd::Delete(vec![0]);
+        let tx_0 = vec![insert_0, update_1, delete_2];
+        unwrap!(data.commit(&tx_0));
+        let insert_3 = MapCmd::Insert((vec![0], vec![0]));
+        let tx_1 = vec![insert_3];
+        unwrap!(data.commit(&tx_1));
+    }
+
+    #[test]
+    fn insert_when_exists_fails() {
+        let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
+        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
+        let tx = vec![insert_0];
+        unwrap!(data.commit(&tx));
+        let insert_1 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
+        let tx = vec![insert_1];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::EntryExists(1), *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+
+        let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
+        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
+        let tx = vec![insert_0];
+        unwrap!(data.commit(&tx));
+        let insert_1 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
+        let tx = vec![insert_1];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::EntryExists(1), *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+
+        let mut data = PublicMap::new(XorName([1; 32]), 10000);
+        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
+        let tx = vec![insert_0];
+        unwrap!(data.commit(&tx));
+        let insert_1 = MapCmd::Insert((vec![0], vec![0]));
+        let tx = vec![insert_1];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::EntryExists(1), *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+
+        let mut data = PrivateMap::new(XorName([1; 32]), 10000);
+        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
+        let tx = vec![insert_0];
+        unwrap!(data.commit(&tx));
+        let insert_1 = MapCmd::Insert((vec![0], vec![0]));
+        let tx = vec![insert_1];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::EntryExists(1), *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+    }
+
+    #[test]
+    fn update_with_wrong_version_fails() {
+        let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
+        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
+        let update_1 = SentriedMapCmd::Update(((vec![0], vec![0]), 1));
+        let update_2 = SentriedMapCmd::Update(((vec![0], vec![0]), 3)); // <-- wrong version
+        let tx = vec![insert_0, update_1, update_2];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::InvalidSuccessor(2), *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+
+        let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
+        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
+        let update_1 = SentriedMapCmd::Update(((vec![0], vec![0]), 1));
+        let update_2 = SentriedMapCmd::Update(((vec![0], vec![0]), 3)); // <-- wrong version
+        let tx = vec![insert_0, update_1, update_2];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::InvalidSuccessor(2), *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+    }
+
+    #[test]
+    fn delete_with_wrong_version_fails() {
+        let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
+        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
+        let delete_1 = SentriedMapCmd::Delete((vec![0], 3)); // <-- wrong version
+        let tx = vec![insert_0, delete_1];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::InvalidSuccessor(1), *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+
+        let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
+        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
+        let delete_1 = SentriedMapCmd::Delete((vec![0], 3)); // <-- wrong version
+        let tx = vec![insert_0, delete_1];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::InvalidSuccessor(1), *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+    }
+
+    #[test]
+    fn re_insert_with_wrong_version_fails() {
+        // PublicSentriedMap
+        let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
+        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
+        let delete_1 = SentriedMapCmd::Delete((vec![0], 1));
+        let tx = vec![insert_0, delete_1];
+        unwrap!(data.commit(&tx));
+        let insert_2 = SentriedMapCmd::Insert(((vec![0], vec![0]), 3)); // <-- wrong version
+        let tx = vec![insert_2];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::InvalidSuccessor(2), *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+
+        // PrivateSentriedMap
+        let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
+        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
+        let delete_1 = SentriedMapCmd::Delete((vec![0], 1));
+        let tx = vec![insert_0, delete_1];
+        unwrap!(data.commit(&tx));
+        let insert_2 = SentriedMapCmd::Insert(((vec![0], vec![0]), 3)); // <-- wrong version
+        let tx = vec![insert_2];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::InvalidSuccessor(2), *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+    }
+    #[test]
+    fn delete_or_update_nonexisting_fails() {
+        // PublicSentriedMap
+        let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
+        // Delete
+        let delete_2 = SentriedMapCmd::Delete((vec![0], 2));
+        let tx = vec![delete_2];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+        // Update
+        let update_3 = SentriedMapCmd::Update(((vec![0], vec![0]), 3));
+        let tx = vec![update_3];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+
+        // PrivateSentriedMap
+        let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
+        // Delete
+        let delete_2 = SentriedMapCmd::Delete((vec![0], 2));
+        let tx = vec![delete_2];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+        // Update
+        let update_3 = SentriedMapCmd::Update(((vec![0], vec![0]), 3));
+        let tx = vec![update_3];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+
+        // PublicMap
+        let mut data = PublicMap::new(XorName([1; 32]), 10000);
+        // Delete
+        let delete_2 = MapCmd::Delete(vec![0]);
+        let tx = vec![delete_2];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+        // Update
+        let update_3 = MapCmd::Update((vec![0], vec![0]));
+        let tx = vec![update_3];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+
+        // PrivateMap
+        let mut data = PrivateMap::new(XorName([1; 32]), 10000);
+        // Delete
+        let delete_2 = MapCmd::Delete(vec![0]);
+        let tx = vec![delete_2];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+        // Update
+        let update_3 = MapCmd::Update((vec![0], vec![0]));
+        let tx = vec![update_3];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+    }
+
+    #[test]
+    fn delete_or_update_deleted_fails() {
+        // PublicSentriedMap
+        let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
+        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
+        let delete_1 = SentriedMapCmd::Delete((vec![0], 1));
+        let tx = vec![insert_0, delete_1];
+        unwrap!(data.commit(&tx));
+        // Delete
+        let delete_2 = SentriedMapCmd::Delete((vec![0], 2));
+        let tx = vec![delete_2];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+        // Update
+        let update_3 = SentriedMapCmd::Update(((vec![0], vec![0]), 3));
+        let tx = vec![update_3];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+
+        // PrivateSentriedMap
+        let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
+        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
+        let delete_1 = SentriedMapCmd::Delete((vec![0], 1));
+        let tx = vec![insert_0, delete_1];
+        unwrap!(data.commit(&tx));
+        // Delete
+        let delete_2 = SentriedMapCmd::Delete((vec![0], 2));
+        let tx = vec![delete_2];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+        // Update
+        let update_3 = SentriedMapCmd::Update(((vec![0], vec![0]), 3));
+        let tx = vec![update_3];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+
+        // PublicMap
+        let mut data = PublicMap::new(XorName([1; 32]), 10000);
+        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
+        let delete_1 = MapCmd::Delete(vec![0]);
+        let tx = vec![insert_0, delete_1];
+        unwrap!(data.commit(&tx));
+        // Delete
+        let delete_2 = MapCmd::Delete(vec![0]);
+        let tx = vec![delete_2];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+        // Update
+        let update_3 = MapCmd::Update((vec![0], vec![0]));
+        let tx = vec![update_3];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+
+        // PrivateMap
+        let mut data = PrivateMap::new(XorName([1; 32]), 10000);
+        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
+        let delete_1 = MapCmd::Delete(vec![0]);
+        let tx = vec![insert_0, delete_1];
+        unwrap!(data.commit(&tx));
+        // Delete
+        let delete_2 = MapCmd::Delete(vec![0]);
+        let tx = vec![delete_2];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+        // Update
+        let update_3 = MapCmd::Update((vec![0], vec![0]));
+        let tx = vec![update_3];
+        match unwrap_err!(data.commit(&tx)) {
+            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
+                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+                _ => assert!(false),
+            },
+            _ => assert!(false),
+        }
+    }
+}

--- a/src/data/tests.rs
+++ b/src/data/tests.rs
@@ -6,502 +6,498 @@
 // modified, or distributed except according to those terms. Please review the Licences for the
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
+use crate::data::map::*;
+use crate::data::*;
+use crate::{EntryError, Error, XorName};
+use unwrap::{unwrap, unwrap_err};
 
-#[cfg(test)]
-mod tests {
-    use crate::data::map::*;
-    use crate::data::*;
-    use crate::{EntryError, Error, XorName};
-    use unwrap::{unwrap, unwrap_err};
+#[test]
+fn insert() {
+    let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
+    let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
+    let insert_1 = SentriedMapCmd::Insert(((vec![1].into(), vec![0]), 0));
+    let insert_2 = SentriedMapCmd::Insert(((vec![2].into(), vec![0]), 0));
+    let tx = vec![insert_0, insert_1, insert_2];
+    unwrap!(data.commit(&tx));
 
-    #[test]
-    fn insert() {
-        let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
-        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
-        let insert_1 = SentriedMapCmd::Insert(((vec![1], vec![0]), 0));
-        let insert_2 = SentriedMapCmd::Insert(((vec![2], vec![0]), 0));
-        let tx = vec![insert_0, insert_1, insert_2];
-        unwrap!(data.commit(&tx));
+    let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
+    let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
+    let insert_1 = SentriedMapCmd::Insert(((vec![1].into(), vec![0]), 0));
+    let insert_2 = SentriedMapCmd::Insert(((vec![2].into(), vec![0]), 0));
+    let tx = vec![insert_0, insert_1, insert_2];
+    unwrap!(data.commit(&tx));
 
-        let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
-        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
-        let insert_1 = SentriedMapCmd::Insert(((vec![1], vec![0]), 0));
-        let insert_2 = SentriedMapCmd::Insert(((vec![2], vec![0]), 0));
-        let tx = vec![insert_0, insert_1, insert_2];
-        unwrap!(data.commit(&tx));
+    let mut data = PublicMap::new(XorName([1; 32]), 10000);
+    let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
+    let insert_1 = MapCmd::Insert((vec![1].into(), vec![0]));
+    let insert_2 = MapCmd::Insert((vec![2].into(), vec![0]));
+    let tx = vec![insert_0, insert_1, insert_2];
+    unwrap!(data.commit(&tx));
 
-        let mut data = PublicMap::new(XorName([1; 32]), 10000);
-        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
-        let insert_1 = MapCmd::Insert((vec![1], vec![0]));
-        let insert_2 = MapCmd::Insert((vec![2], vec![0]));
-        let tx = vec![insert_0, insert_1, insert_2];
-        unwrap!(data.commit(&tx));
+    let mut data = PrivateMap::new(XorName([1; 32]), 10000);
+    let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
+    let insert_1 = MapCmd::Insert((vec![1].into(), vec![0]));
+    let insert_2 = MapCmd::Insert((vec![2].into(), vec![0]));
+    let tx = vec![insert_0, insert_1, insert_2];
+    unwrap!(data.commit(&tx))
+}
 
-        let mut data = PrivateMap::new(XorName([1; 32]), 10000);
-        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
-        let insert_1 = MapCmd::Insert((vec![1], vec![0]));
-        let insert_2 = MapCmd::Insert((vec![2], vec![0]));
-        let tx = vec![insert_0, insert_1, insert_2];
-        unwrap!(data.commit(&tx))
+#[test]
+fn update() {
+    let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
+    let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
+    let update_1 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 1));
+    let update_2 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 2));
+    let tx = vec![insert_0, update_1, update_2];
+    unwrap!(data.commit(&tx));
+
+    let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
+    let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
+    let update_1 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 1));
+    let update_2 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 2));
+    let tx = vec![insert_0, update_1, update_2];
+    unwrap!(data.commit(&tx));
+
+    let mut data = PublicMap::new(XorName([1; 32]), 10000);
+    let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
+    let update_1 = MapCmd::Update((vec![0].into(), vec![0]));
+    let update_2 = MapCmd::Update((vec![0].into(), vec![0]));
+    let tx = vec![insert_0, update_1, update_2];
+    unwrap!(data.commit(&tx));
+
+    let mut data = PrivateMap::new(XorName([1; 32]), 10000);
+    let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
+    let update_1 = MapCmd::Update((vec![0].into(), vec![0]));
+    let update_2 = MapCmd::Update((vec![0].into(), vec![0]));
+    let tx = vec![insert_0, update_1, update_2];
+    unwrap!(data.commit(&tx))
+}
+
+#[test]
+fn delete() {
+    let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
+    let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
+    let update_1 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 1));
+    let delete_2 = SentriedMapCmd::Delete((vec![0].into(), 2));
+    let tx = vec![insert_0, update_1, delete_2];
+    unwrap!(data.commit(&tx));
+
+    let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
+    let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
+    let update_1 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 1));
+    let delete_2 = SentriedMapCmd::Delete((vec![0].into(), 2));
+    let tx = vec![insert_0, update_1, delete_2];
+    unwrap!(data.commit(&tx));
+
+    let mut data = PublicMap::new(XorName([1; 32]), 10000);
+    let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
+    let update_1 = MapCmd::Update((vec![0].into(), vec![0]));
+    let delete_2 = MapCmd::Delete(vec![0].into());
+    let tx = vec![insert_0, update_1, delete_2];
+    unwrap!(data.commit(&tx));
+
+    let mut data = PrivateMap::new(XorName([1; 32]), 10000);
+    let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
+    let update_1 = MapCmd::Update((vec![0].into(), vec![0]));
+    let delete_2 = MapCmd::Delete(vec![0].into());
+    let tx = vec![insert_0, update_1, delete_2];
+    unwrap!(data.commit(&tx))
+}
+
+#[test]
+fn re_insert() {
+    let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
+    let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
+    let update_1 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 1));
+    let delete_2 = SentriedMapCmd::Delete((vec![0].into(), 2));
+    let tx_0 = vec![insert_0, update_1, delete_2];
+    unwrap!(data.commit(&tx_0));
+    let insert_3 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 3));
+    let tx_1 = vec![insert_3];
+    unwrap!(data.commit(&tx_1));
+
+    let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
+    let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
+    let update_1 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 1));
+    let delete_2 = SentriedMapCmd::Delete((vec![0].into(), 2));
+    let tx_0 = vec![insert_0, update_1, delete_2];
+    unwrap!(data.commit(&tx_0));
+    let insert_3 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 3));
+    let tx_1 = vec![insert_3];
+    unwrap!(data.commit(&tx_1));
+
+    let mut data = PublicMap::new(XorName([1; 32]), 10000);
+    let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
+    let update_1 = MapCmd::Update((vec![0].into(), vec![0]));
+    let delete_2 = MapCmd::Delete(vec![0].into());
+    let tx_0 = vec![insert_0, update_1, delete_2];
+    unwrap!(data.commit(&tx_0));
+    let insert_3 = MapCmd::Insert((vec![0].into(), vec![0]));
+    let tx_1 = vec![insert_3];
+    unwrap!(data.commit(&tx_1));
+
+    let mut data = PrivateMap::new(XorName([1; 32]), 10000);
+    let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
+    let update_1 = MapCmd::Update((vec![0].into(), vec![0]));
+    let delete_2 = MapCmd::Delete(vec![0].into());
+    let tx_0 = vec![insert_0, update_1, delete_2];
+    unwrap!(data.commit(&tx_0));
+    let insert_3 = MapCmd::Insert((vec![0].into(), vec![0]));
+    let tx_1 = vec![insert_3];
+    unwrap!(data.commit(&tx_1));
+}
+
+#[test]
+fn insert_when_exists_fails() {
+    let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
+    let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
+    let tx = vec![insert_0];
+    unwrap!(data.commit(&tx));
+    let insert_1 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
+    let tx = vec![insert_1];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::EntryExists(1), *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
     }
 
-    #[test]
-    fn update() {
-        let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
-        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
-        let update_1 = SentriedMapCmd::Update(((vec![0], vec![0]), 1));
-        let update_2 = SentriedMapCmd::Update(((vec![0], vec![0]), 2));
-        let tx = vec![insert_0, update_1, update_2];
-        unwrap!(data.commit(&tx));
-
-        let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
-        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
-        let update_1 = SentriedMapCmd::Update(((vec![0], vec![0]), 1));
-        let update_2 = SentriedMapCmd::Update(((vec![0], vec![0]), 2));
-        let tx = vec![insert_0, update_1, update_2];
-        unwrap!(data.commit(&tx));
-
-        let mut data = PublicMap::new(XorName([1; 32]), 10000);
-        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
-        let update_1 = MapCmd::Update((vec![0], vec![0]));
-        let update_2 = MapCmd::Update((vec![0], vec![0]));
-        let tx = vec![insert_0, update_1, update_2];
-        unwrap!(data.commit(&tx));
-
-        let mut data = PrivateMap::new(XorName([1; 32]), 10000);
-        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
-        let update_1 = MapCmd::Update((vec![0], vec![0]));
-        let update_2 = MapCmd::Update((vec![0], vec![0]));
-        let tx = vec![insert_0, update_1, update_2];
-        unwrap!(data.commit(&tx))
+    let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
+    let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
+    let tx = vec![insert_0];
+    unwrap!(data.commit(&tx));
+    let insert_1 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
+    let tx = vec![insert_1];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::EntryExists(1), *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
     }
 
-    #[test]
-    fn delete() {
-        let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
-        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
-        let update_1 = SentriedMapCmd::Update(((vec![0], vec![0]), 1));
-        let delete_2 = SentriedMapCmd::Delete((vec![0], 2));
-        let tx = vec![insert_0, update_1, delete_2];
-        unwrap!(data.commit(&tx));
-
-        let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
-        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
-        let update_1 = SentriedMapCmd::Update(((vec![0], vec![0]), 1));
-        let delete_2 = SentriedMapCmd::Delete((vec![0], 2));
-        let tx = vec![insert_0, update_1, delete_2];
-        unwrap!(data.commit(&tx));
-
-        let mut data = PublicMap::new(XorName([1; 32]), 10000);
-        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
-        let update_1 = MapCmd::Update((vec![0], vec![0]));
-        let delete_2 = MapCmd::Delete(vec![0]);
-        let tx = vec![insert_0, update_1, delete_2];
-        unwrap!(data.commit(&tx));
-
-        let mut data = PrivateMap::new(XorName([1; 32]), 10000);
-        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
-        let update_1 = MapCmd::Update((vec![0], vec![0]));
-        let delete_2 = MapCmd::Delete(vec![0]);
-        let tx = vec![insert_0, update_1, delete_2];
-        unwrap!(data.commit(&tx))
+    let mut data = PublicMap::new(XorName([1; 32]), 10000);
+    let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
+    let tx = vec![insert_0];
+    unwrap!(data.commit(&tx));
+    let insert_1 = MapCmd::Insert((vec![0].into(), vec![0]));
+    let tx = vec![insert_1];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::EntryExists(1), *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
     }
 
-    #[test]
-    fn re_insert() {
-        let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
-        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
-        let update_1 = SentriedMapCmd::Update(((vec![0], vec![0]), 1));
-        let delete_2 = SentriedMapCmd::Delete((vec![0], 2));
-        let tx_0 = vec![insert_0, update_1, delete_2];
-        unwrap!(data.commit(&tx_0));
-        let insert_3 = SentriedMapCmd::Insert(((vec![0], vec![0]), 3));
-        let tx_1 = vec![insert_3];
-        unwrap!(data.commit(&tx_1));
+    let mut data = PrivateMap::new(XorName([1; 32]), 10000);
+    let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
+    let tx = vec![insert_0];
+    unwrap!(data.commit(&tx));
+    let insert_1 = MapCmd::Insert((vec![0].into(), vec![0]));
+    let tx = vec![insert_1];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::EntryExists(1), *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
+    }
+}
 
-        let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
-        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
-        let update_1 = SentriedMapCmd::Update(((vec![0], vec![0]), 1));
-        let delete_2 = SentriedMapCmd::Delete((vec![0], 2));
-        let tx_0 = vec![insert_0, update_1, delete_2];
-        unwrap!(data.commit(&tx_0));
-        let insert_3 = SentriedMapCmd::Insert(((vec![0], vec![0]), 3));
-        let tx_1 = vec![insert_3];
-        unwrap!(data.commit(&tx_1));
-
-        let mut data = PublicMap::new(XorName([1; 32]), 10000);
-        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
-        let update_1 = MapCmd::Update((vec![0], vec![0]));
-        let delete_2 = MapCmd::Delete(vec![0]);
-        let tx_0 = vec![insert_0, update_1, delete_2];
-        unwrap!(data.commit(&tx_0));
-        let insert_3 = MapCmd::Insert((vec![0], vec![0]));
-        let tx_1 = vec![insert_3];
-        unwrap!(data.commit(&tx_1));
-
-        let mut data = PrivateMap::new(XorName([1; 32]), 10000);
-        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
-        let update_1 = MapCmd::Update((vec![0], vec![0]));
-        let delete_2 = MapCmd::Delete(vec![0]);
-        let tx_0 = vec![insert_0, update_1, delete_2];
-        unwrap!(data.commit(&tx_0));
-        let insert_3 = MapCmd::Insert((vec![0], vec![0]));
-        let tx_1 = vec![insert_3];
-        unwrap!(data.commit(&tx_1));
+#[test]
+fn update_with_wrong_version_fails() {
+    let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
+    let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
+    let update_1 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 1));
+    let update_2 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 3)); // <-- wrong version
+    let tx = vec![insert_0, update_1, update_2];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::InvalidSuccessor(2), *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
     }
 
-    #[test]
-    fn insert_when_exists_fails() {
-        let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
-        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
-        let tx = vec![insert_0];
-        unwrap!(data.commit(&tx));
-        let insert_1 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
-        let tx = vec![insert_1];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::EntryExists(1), *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
+    let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
+    let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
+    let update_1 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 1));
+    let update_2 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 3)); // <-- wrong version
+    let tx = vec![insert_0, update_1, update_2];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::InvalidSuccessor(2), *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
+    }
+}
 
-        let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
-        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
-        let tx = vec![insert_0];
-        unwrap!(data.commit(&tx));
-        let insert_1 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
-        let tx = vec![insert_1];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::EntryExists(1), *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
-
-        let mut data = PublicMap::new(XorName([1; 32]), 10000);
-        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
-        let tx = vec![insert_0];
-        unwrap!(data.commit(&tx));
-        let insert_1 = MapCmd::Insert((vec![0], vec![0]));
-        let tx = vec![insert_1];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::EntryExists(1), *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
-
-        let mut data = PrivateMap::new(XorName([1; 32]), 10000);
-        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
-        let tx = vec![insert_0];
-        unwrap!(data.commit(&tx));
-        let insert_1 = MapCmd::Insert((vec![0], vec![0]));
-        let tx = vec![insert_1];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::EntryExists(1), *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
+#[test]
+fn delete_with_wrong_version_fails() {
+    let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
+    let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
+    let delete_1 = SentriedMapCmd::Delete((vec![0].into(), 3)); // <-- wrong version
+    let tx = vec![insert_0, delete_1];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::InvalidSuccessor(1), *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
     }
 
-    #[test]
-    fn update_with_wrong_version_fails() {
-        let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
-        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
-        let update_1 = SentriedMapCmd::Update(((vec![0], vec![0]), 1));
-        let update_2 = SentriedMapCmd::Update(((vec![0], vec![0]), 3)); // <-- wrong version
-        let tx = vec![insert_0, update_1, update_2];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::InvalidSuccessor(2), *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
+    let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
+    let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
+    let delete_1 = SentriedMapCmd::Delete((vec![0].into(), 3)); // <-- wrong version
+    let tx = vec![insert_0, delete_1];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::InvalidSuccessor(1), *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
+    }
+}
 
-        let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
-        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
-        let update_1 = SentriedMapCmd::Update(((vec![0], vec![0]), 1));
-        let update_2 = SentriedMapCmd::Update(((vec![0], vec![0]), 3)); // <-- wrong version
-        let tx = vec![insert_0, update_1, update_2];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::InvalidSuccessor(2), *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
+#[test]
+fn re_insert_with_wrong_version_fails() {
+    // PublicSentriedMap
+    let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
+    let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
+    let delete_1 = SentriedMapCmd::Delete((vec![0].into(), 1));
+    let tx = vec![insert_0, delete_1];
+    unwrap!(data.commit(&tx));
+    let insert_2 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 3)); // <-- wrong version
+    let tx = vec![insert_2];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::InvalidSuccessor(2), *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
     }
 
-    #[test]
-    fn delete_with_wrong_version_fails() {
-        let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
-        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
-        let delete_1 = SentriedMapCmd::Delete((vec![0], 3)); // <-- wrong version
-        let tx = vec![insert_0, delete_1];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::InvalidSuccessor(1), *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
-
-        let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
-        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
-        let delete_1 = SentriedMapCmd::Delete((vec![0], 3)); // <-- wrong version
-        let tx = vec![insert_0, delete_1];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::InvalidSuccessor(1), *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
+    // PrivateSentriedMap
+    let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
+    let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
+    let delete_1 = SentriedMapCmd::Delete((vec![0].into(), 1));
+    let tx = vec![insert_0, delete_1];
+    unwrap!(data.commit(&tx));
+    let insert_2 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 3)); // <-- wrong version
+    let tx = vec![insert_2];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::InvalidSuccessor(2), *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
+    }
+}
+#[test]
+fn delete_or_update_nonexisting_fails() {
+    // PublicSentriedMap
+    let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
+    // Delete
+    let delete_2 = SentriedMapCmd::Delete((vec![0].into(), 2));
+    let tx = vec![delete_2];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
+    }
+    // Update
+    let update_3 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 3));
+    let tx = vec![update_3];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
     }
 
-    #[test]
-    fn re_insert_with_wrong_version_fails() {
-        // PublicSentriedMap
-        let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
-        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
-        let delete_1 = SentriedMapCmd::Delete((vec![0], 1));
-        let tx = vec![insert_0, delete_1];
-        unwrap!(data.commit(&tx));
-        let insert_2 = SentriedMapCmd::Insert(((vec![0], vec![0]), 3)); // <-- wrong version
-        let tx = vec![insert_2];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::InvalidSuccessor(2), *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
-
-        // PrivateSentriedMap
-        let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
-        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
-        let delete_1 = SentriedMapCmd::Delete((vec![0], 1));
-        let tx = vec![insert_0, delete_1];
-        unwrap!(data.commit(&tx));
-        let insert_2 = SentriedMapCmd::Insert(((vec![0], vec![0]), 3)); // <-- wrong version
-        let tx = vec![insert_2];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::InvalidSuccessor(2), *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
+    // PrivateSentriedMap
+    let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
+    // Delete
+    let delete_2 = SentriedMapCmd::Delete((vec![0].into(), 2));
+    let tx = vec![delete_2];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
     }
-    #[test]
-    fn delete_or_update_nonexisting_fails() {
-        // PublicSentriedMap
-        let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
-        // Delete
-        let delete_2 = SentriedMapCmd::Delete((vec![0], 2));
-        let tx = vec![delete_2];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
-        // Update
-        let update_3 = SentriedMapCmd::Update(((vec![0], vec![0]), 3));
-        let tx = vec![update_3];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
-
-        // PrivateSentriedMap
-        let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
-        // Delete
-        let delete_2 = SentriedMapCmd::Delete((vec![0], 2));
-        let tx = vec![delete_2];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
-        // Update
-        let update_3 = SentriedMapCmd::Update(((vec![0], vec![0]), 3));
-        let tx = vec![update_3];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
-
-        // PublicMap
-        let mut data = PublicMap::new(XorName([1; 32]), 10000);
-        // Delete
-        let delete_2 = MapCmd::Delete(vec![0]);
-        let tx = vec![delete_2];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
-        // Update
-        let update_3 = MapCmd::Update((vec![0], vec![0]));
-        let tx = vec![update_3];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
-
-        // PrivateMap
-        let mut data = PrivateMap::new(XorName([1; 32]), 10000);
-        // Delete
-        let delete_2 = MapCmd::Delete(vec![0]);
-        let tx = vec![delete_2];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
-        // Update
-        let update_3 = MapCmd::Update((vec![0], vec![0]));
-        let tx = vec![update_3];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
+    // Update
+    let update_3 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 3));
+    let tx = vec![update_3];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
     }
 
-    #[test]
-    fn delete_or_update_deleted_fails() {
-        // PublicSentriedMap
-        let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
-        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
-        let delete_1 = SentriedMapCmd::Delete((vec![0], 1));
-        let tx = vec![insert_0, delete_1];
-        unwrap!(data.commit(&tx));
-        // Delete
-        let delete_2 = SentriedMapCmd::Delete((vec![0], 2));
-        let tx = vec![delete_2];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
-        // Update
-        let update_3 = SentriedMapCmd::Update(((vec![0], vec![0]), 3));
-        let tx = vec![update_3];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
+    // PublicMap
+    let mut data = PublicMap::new(XorName([1; 32]), 10000);
+    // Delete
+    let delete_2 = MapCmd::Delete(vec![0].into());
+    let tx = vec![delete_2];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
+    }
+    // Update
+    let update_3 = MapCmd::Update((vec![0].into(), vec![0]));
+    let tx = vec![update_3];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
+    }
 
-        // PrivateSentriedMap
-        let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
-        let insert_0 = SentriedMapCmd::Insert(((vec![0], vec![0]), 0));
-        let delete_1 = SentriedMapCmd::Delete((vec![0], 1));
-        let tx = vec![insert_0, delete_1];
-        unwrap!(data.commit(&tx));
-        // Delete
-        let delete_2 = SentriedMapCmd::Delete((vec![0], 2));
-        let tx = vec![delete_2];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
-        // Update
-        let update_3 = SentriedMapCmd::Update(((vec![0], vec![0]), 3));
-        let tx = vec![update_3];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
+    // PrivateMap
+    let mut data = PrivateMap::new(XorName([1; 32]), 10000);
+    // Delete
+    let delete_2 = MapCmd::Delete(vec![0].into());
+    let tx = vec![delete_2];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
+    }
+    // Update
+    let update_3 = MapCmd::Update((vec![0].into(), vec![0]));
+    let tx = vec![update_3];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
+    }
+}
 
-        // PublicMap
-        let mut data = PublicMap::new(XorName([1; 32]), 10000);
-        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
-        let delete_1 = MapCmd::Delete(vec![0]);
-        let tx = vec![insert_0, delete_1];
-        unwrap!(data.commit(&tx));
-        // Delete
-        let delete_2 = MapCmd::Delete(vec![0]);
-        let tx = vec![delete_2];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
-        // Update
-        let update_3 = MapCmd::Update((vec![0], vec![0]));
-        let tx = vec![update_3];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
+#[test]
+fn delete_or_update_deleted_fails() {
+    // PublicSentriedMap
+    let mut data = PublicSentriedMap::new(XorName([1; 32]), 10000);
+    let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
+    let delete_1 = SentriedMapCmd::Delete((vec![0].into(), 1));
+    let tx = vec![insert_0, delete_1];
+    unwrap!(data.commit(&tx));
+    // Delete
+    let delete_2 = SentriedMapCmd::Delete((vec![0].into(), 2));
+    let tx = vec![delete_2];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
+    }
+    // Update
+    let update_3 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 3));
+    let tx = vec![update_3];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
+    }
 
-        // PrivateMap
-        let mut data = PrivateMap::new(XorName([1; 32]), 10000);
-        let insert_0 = MapCmd::Insert((vec![0], vec![0]));
-        let delete_1 = MapCmd::Delete(vec![0]);
-        let tx = vec![insert_0, delete_1];
-        unwrap!(data.commit(&tx));
-        // Delete
-        let delete_2 = MapCmd::Delete(vec![0]);
-        let tx = vec![delete_2];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
-        // Update
-        let update_3 = MapCmd::Update((vec![0], vec![0]));
-        let tx = vec![update_3];
-        match unwrap_err!(data.commit(&tx)) {
-            Error::InvalidEntryActions(errors) => match errors.get(&vec![0]) {
-                Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
+    // PrivateSentriedMap
+    let mut data = PrivateSentriedMap::new(XorName([1; 32]), 10000);
+    let insert_0 = SentriedMapCmd::Insert(((vec![0].into(), vec![0]), 0));
+    let delete_1 = SentriedMapCmd::Delete((vec![0].into(), 1));
+    let tx = vec![insert_0, delete_1];
+    unwrap!(data.commit(&tx));
+    // Delete
+    let delete_2 = SentriedMapCmd::Delete((vec![0].into(), 2));
+    let tx = vec![delete_2];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
+    }
+    // Update
+    let update_3 = SentriedMapCmd::Update(((vec![0].into(), vec![0]), 3));
+    let tx = vec![update_3];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
+    }
+
+    // PublicMap
+    let mut data = PublicMap::new(XorName([1; 32]), 10000);
+    let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
+    let delete_1 = MapCmd::Delete(vec![0].into());
+    let tx = vec![insert_0, delete_1];
+    unwrap!(data.commit(&tx));
+    // Delete
+    let delete_2 = MapCmd::Delete(vec![0].into());
+    let tx = vec![delete_2];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
+    }
+    // Update
+    let update_3 = MapCmd::Update((vec![0].into(), vec![0]));
+    let tx = vec![update_3];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
+    }
+
+    // PrivateMap
+    let mut data = PrivateMap::new(XorName([1; 32]), 10000);
+    let insert_0 = MapCmd::Insert((vec![0].into(), vec![0]));
+    let delete_1 = MapCmd::Delete(vec![0].into());
+    let tx = vec![insert_0, delete_1];
+    unwrap!(data.commit(&tx));
+    // Delete
+    let delete_2 = MapCmd::Delete(vec![0].into());
+    let tx = vec![delete_2];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
+    }
+    // Update
+    let update_3 = MapCmd::Update((vec![0].into(), vec![0]));
+    let tx = vec![update_3];
+    match unwrap_err!(data.commit(&tx)) {
+        Error::InvalidEntryActions(errors) => match errors.get(&vec![0].into()) {
+            Some(error) => assert_eq!(EntryError::NoSuchEntry, *error),
+            _ => panic!(),
+        },
+        _ => panic!(),
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,6 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
+use crate::shared_types::Key;
 use crate::ADataEntries;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -50,7 +51,7 @@ pub enum Error {
     /// Exceeded a limit on a number of entries
     TooManyEntries,
     /// Some entry actions are not valid.
-    InvalidEntryActions(BTreeMap<Vec<u8>, EntryError>),
+    InvalidEntryActions(BTreeMap<Key, EntryError>),
     /// Key does not exist
     NoSuchKey,
     /// The key(s) of the entry or entries contained in this error already exist

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -200,8 +200,8 @@ impl error::Error for Error {
 pub enum EntryError {
     /// Entry does not exists.
     NoSuchEntry,
-    /// Entry already exists. Contains the current entry Key.
-    EntryExists(u8),
-    /// Invalid version when updating an entry. Contains the current entry Key.
-    InvalidSuccessor(u8),
+    /// Entry already exists. Contains the current entry version.
+    EntryExists(u64),
+    /// Invalid version when updating an entry. Contains the current entry version.
+    InvalidSuccessor(u64),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,9 @@
 )]
 
 mod append_only_data;
+mod authorization;
 mod coins;
+mod data;
 mod errors;
 mod identity;
 mod immutable_data;
@@ -37,6 +39,7 @@ mod keys;
 mod mutable_data;
 mod request;
 mod response;
+mod shared_types;
 mod utils;
 
 pub use append_only_data::{
@@ -51,6 +54,7 @@ pub use append_only_data::{
     UnseqAppendOnly, User as ADataUser,
 };
 pub use coins::{Coins, MAX_COINS_VALUE};
+pub use data::map::*;
 pub use errors::{EntryError, Error, Result};
 pub use identity::{
     app::{FullId as AppFullId, PublicId as AppPublicId},

--- a/src/mutable_data.rs
+++ b/src/mutable_data.rs
@@ -605,7 +605,7 @@ impl SeqData {
                 Entry::Occupied(entry) => {
                     let _ = errors.insert(
                         entry.key().clone(),
-                        EntryError::EntryExists(entry.get().version as u8),
+                        EntryError::EntryExists(entry.get().version),
                     );
                 }
                 Entry::Vacant(entry) => {
@@ -623,7 +623,7 @@ impl SeqData {
                     } else {
                         let _ = errors.insert(
                             entry.key().clone(),
-                            EntryError::InvalidSuccessor(current_version as u8),
+                            EntryError::InvalidSuccessor(current_version),
                         );
                     }
                 }
@@ -642,7 +642,7 @@ impl SeqData {
                     } else {
                         let _ = errors.insert(
                             entry.key().clone(),
-                            EntryError::InvalidSuccessor(current_version as u8),
+                            EntryError::InvalidSuccessor(current_version),
                         );
                     }
                 }

--- a/src/mutable_data.rs
+++ b/src/mutable_data.rs
@@ -476,7 +476,7 @@ impl UnseqData {
         for (key, val) in insert {
             match new_data.entry(key) {
                 Entry::Occupied(entry) => {
-                    let _ = errors.insert(entry.key().clone(), EntryError::EntryExists(0));
+                    let _ = errors.insert(entry.key().clone().into(), EntryError::EntryExists(0));
                 }
                 Entry::Vacant(entry) => {
                     let _ = entry.insert(val);
@@ -490,7 +490,7 @@ impl UnseqData {
                     let _ = entry.insert(val);
                 }
                 Entry::Vacant(entry) => {
-                    let _ = errors.insert(entry.key().clone(), EntryError::NoSuchEntry);
+                    let _ = errors.insert(entry.key().clone().into(), EntryError::NoSuchEntry);
                 }
             }
         }
@@ -501,7 +501,7 @@ impl UnseqData {
                     let _ = new_data.remove(&key);
                 }
                 Entry::Vacant(entry) => {
-                    let _ = errors.insert(entry.key().clone(), EntryError::NoSuchEntry);
+                    let _ = errors.insert(entry.key().clone().into(), EntryError::NoSuchEntry);
                 }
             }
         }
@@ -604,7 +604,7 @@ impl SeqData {
             match new_data.entry(key) {
                 Entry::Occupied(entry) => {
                     let _ = errors.insert(
-                        entry.key().clone(),
+                        entry.key().clone().into(),
                         EntryError::EntryExists(entry.get().version),
                     );
                 }
@@ -622,13 +622,13 @@ impl SeqData {
                         let _ = entry.insert(val);
                     } else {
                         let _ = errors.insert(
-                            entry.key().clone(),
+                            entry.key().clone().into(),
                             EntryError::InvalidSuccessor(current_version),
                         );
                     }
                 }
                 Entry::Vacant(entry) => {
-                    let _ = errors.insert(entry.key().clone(), EntryError::NoSuchEntry);
+                    let _ = errors.insert(entry.key().clone().into(), EntryError::NoSuchEntry);
                 }
             }
         }
@@ -641,13 +641,13 @@ impl SeqData {
                         let _ = new_data.remove(&key);
                     } else {
                         let _ = errors.insert(
-                            entry.key().clone(),
+                            entry.key().clone().into(),
                             EntryError::InvalidSuccessor(current_version),
                         );
                     }
                 }
                 Entry::Vacant(entry) => {
-                    let _ = errors.insert(entry.key().clone(), EntryError::NoSuchEntry);
+                    let _ = errors.insert(entry.key().clone().into(), EntryError::NoSuchEntry);
                 }
             }
         }

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -1,0 +1,213 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+use crate::{utils, PublicKey, Result, XorName};
+use multibase::Decodable;
+use serde::{Deserialize, Serialize};
+use std::ops::Range;
+
+pub type Key = Vec<u8>;
+pub type Value = Vec<u8>;
+pub type KvPair = (Key, Value);
+pub type Values = Vec<Value>;
+pub type Keys = Vec<Key>;
+
+/// Marker for sentried data.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
+pub struct Sentried;
+
+/// Marker for non-sentried data.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
+pub struct NonSentried;
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
+pub enum User {
+    Anyone,
+    Specific(PublicKey),
+}
+
+#[derive(Copy, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum Version {
+    FromStart(u64), // Absolute index
+    FromEnd(u64),   // Relative Version - start counting from the end
+}
+
+impl From<u64> for Version {
+    fn from(version: u64) -> Self {
+        Version::FromStart(version)
+    }
+}
+
+// Set of data, owners, permissions versions.
+#[derive(Copy, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ExpectedVersions {
+    expected_data_version: u64,
+    expected_owners_version: u64,
+    expected_access_list_version: u64,
+}
+
+impl ExpectedVersions {
+    pub fn new(
+        expected_data_version: u64,
+        expected_owners_version: u64,
+        expected_access_list_version: u64,
+    ) -> Self {
+        ExpectedVersions {
+            expected_data_version,
+            expected_owners_version,
+            expected_access_list_version,
+        }
+    }
+
+    pub fn expected_data_version(&self) -> u64 {
+        self.expected_data_version
+    }
+
+    pub fn expected_owners_version(&self) -> u64 {
+        self.expected_owners_version
+    }
+
+    pub fn expected_access_list_version(&self) -> u64 {
+        self.expected_access_list_version
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Debug)]
+pub struct Owner {
+    pub public_key: PublicKey,
+    /// The expected Version of the data at the time this ownership change is to become valid.
+    pub expected_data_version: u64,
+    /// The expected Version of the permissions at the time this ownership change is to become valid.
+    pub expected_access_list_version: u64,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
+pub enum Kind {
+    PublicSentried,
+    Public,
+    PrivateSentried,
+    Private,
+}
+
+impl Kind {
+    pub fn is_public(self) -> bool {
+        self == Kind::PublicSentried || self == Kind::Public
+    }
+
+    pub fn is_private(self) -> bool {
+        !self.is_public()
+    }
+
+    pub fn is_sentried(self) -> bool {
+        self == Kind::PublicSentried || self == Kind::PrivateSentried
+    }
+
+    /// Creates `Kind` from `public` and `sentried` flags.
+    pub fn from_flags(public: bool, sentried: bool) -> Self {
+        match (public, sentried) {
+            (true, true) => Kind::PublicSentried,
+            (true, false) => Kind::Public,
+            (false, true) => Kind::PrivateSentried,
+            (false, false) => Kind::Private,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
+pub enum DataAddress {
+    Map(Address),
+    Sequence(Address),
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
+pub enum Address {
+    PublicSentried { name: XorName, tag: u64 },
+    Public { name: XorName, tag: u64 },
+    PrivateSentried { name: XorName, tag: u64 },
+    Private { name: XorName, tag: u64 },
+}
+
+impl Address {
+    pub fn from_kind(kind: Kind, name: XorName, tag: u64) -> Self {
+        match kind {
+            Kind::PublicSentried => Address::PublicSentried { name, tag },
+            Kind::Public => Address::Public { name, tag },
+            Kind::PrivateSentried => Address::PrivateSentried { name, tag },
+            Kind::Private => Address::Private { name, tag },
+        }
+    }
+
+    pub fn kind(&self) -> Kind {
+        match self {
+            Address::PublicSentried { .. } => Kind::PublicSentried,
+            Address::Public { .. } => Kind::Public,
+            Address::PrivateSentried { .. } => Kind::PrivateSentried,
+            Address::Private { .. } => Kind::Private,
+        }
+    }
+
+    pub fn name(&self) -> &XorName {
+        match self {
+            Address::PublicSentried { ref name, .. }
+            | Address::Public { ref name, .. }
+            | Address::PrivateSentried { ref name, .. }
+            | Address::Private { ref name, .. } => name,
+        }
+    }
+
+    pub fn tag(&self) -> u64 {
+        match self {
+            Address::PublicSentried { tag, .. }
+            | Address::Public { tag, .. }
+            | Address::PrivateSentried { tag, .. }
+            | Address::Private { tag, .. } => *tag,
+        }
+    }
+
+    pub fn is_public(&self) -> bool {
+        self.kind().is_public()
+    }
+
+    pub fn is_private(&self) -> bool {
+        self.kind().is_private()
+    }
+
+    pub fn is_sentried(&self) -> bool {
+        self.kind().is_sentried()
+    }
+
+    /// Returns the Address serialised and encoded in z-base-32.
+    pub fn encode_to_zbase32(&self) -> String {
+        utils::encode(&self)
+    }
+
+    /// Create from z-base-32 encoded string.
+    pub fn decode_from_zbase32<I: Decodable>(encoded: I) -> Result<Self> {
+        utils::decode(encoded)
+    }
+}
+
+pub fn to_absolute_version(version: Version, count: usize) -> Option<usize> {
+    match version {
+        Version::FromStart(version) if version as usize <= count => Some(version as usize),
+        Version::FromStart(_) => None,
+        Version::FromEnd(version) => count.checked_sub(version as usize),
+    }
+}
+
+pub fn to_absolute_range(start: Version, end: Version, count: usize) -> Option<Range<usize>> {
+    let start = to_absolute_version(start, count)?;
+    let end = to_absolute_version(end, count)?;
+
+    if start <= end {
+        Some(start..end)
+    } else {
+        None
+    }
+}

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -10,9 +10,33 @@
 use crate::{utils, PublicKey, Result, XorName};
 use multibase::Decodable;
 use serde::{Deserialize, Serialize};
+use std::ops::Deref;
 use std::ops::Range;
 
-pub type Key = Vec<u8>;
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default, Debug)]
+pub struct Key(Vec<u8>);
+
+impl Key {
+    pub fn get(&self) -> &Vec<u8> {
+        &self.0
+    }
+}
+
+impl Deref for Key {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<Vec<u8>> for Key {
+    fn from(vec: Vec<u8>) -> Self {
+        Key(vec)
+    }
+}
+
+// pub type Key = Vec<u8>;
 pub type Value = Vec<u8>;
 pub type KvPair = (Key, Value);
 pub type Values = Vec<Value>;

--- a/src/shared_types.rs
+++ b/src/shared_types.rs
@@ -17,8 +17,8 @@ use std::ops::Range;
 pub struct Key(Vec<u8>);
 
 impl Key {
-    pub fn get(&self) -> &Vec<u8> {
-        &self.0
+    pub fn get(&self) -> Vec<u8> {
+        self.0.to_vec()
     }
 }
 


### PR DESCRIPTION
Draft for discussions with partial implementations. **Not to be merged.**

**NB:** The draft is primarily intended to focus on discussion about the **concept changes** and **idiomatic rust**. Small things, like typos or smallish wording changes in docs, indentation and similar trivialities can be addressed in the real PR (if they are still present). 
Anything off that is already present in current code base (i.e. not part of this change) could perhaps better go into a proper issue - as to keep discussion focused around the actual changes.

For the full implementation, see https://github.com/oetyng/safe-nd/tree/datatypes-refinement-demo

Based on `access_control` branch.

- Adds `map.rs` in `data` mod.
- Adds rudimentary tests for `map`.

Step **4.2** adds the `request` and `response` APIs for the `map` data type.