### PR TITLE
Update changelog with v 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@
 - Change the Client<->Node handshake protocol: it replaces a one-purpose `Challenge` enum with a more extensive pair of enums, `HandshakeRequest` and `HandshakeResponse`.
 - Fix pedantic clippy errors.
 
+## [0.6.2]
+
+- Add `version` and `set_version` functions to `SeqEntryAction`.
+
 ## [0.6.1]
+
 - Implement `From` trait for `id::client::FullId` to allow conversion from supported key types.
 
 ## [0.6.0]


### PR DESCRIPTION
- safe-nd v0.6.2 was released manually by branching off 0.6.1 and
cherry-picking commit 70ddc1d. This commit updates the changelog with
information about v0.6.2