### PR TITLE
Fix auto publishing

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -67,7 +67,7 @@ jobs:
       - shell: bash
         id: commit_message
         run: |
-          commit_message=$(git log --format=%B -n 1 ${{ github.sha }})
+          commit_message=$(git log --no-merges --format=%B -n 1 ${{ github.sha }})
           echo "::set-output name=commit_message::$commit_message"
       - shell: bash
         id: versioning


### PR DESCRIPTION
add --no-merges to exclude merge commits when fetching the latest commit for version change PRs