### PR TITLE
refactor/request: introduce read/write

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.10.0"
 
 [dependencies]
 # Ensure bincode version is identical to that in SAFE Client Libs and SAFE Vault.
-bincode = "1.2.1"
+bincode = "1.1.4"
 ed25519-dalek = "~0.9.1"
 hex_fmt = "~0.3.0"
 multibase = "~0.6.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,11 +70,11 @@ pub use response::{Response, TryFromError};
 pub use sequence::{
     Action as SDataAction, Address as SDataAddress, Data as SData, Entries as SDataEntries,
     Entry as SDataEntry, Index as SDataIndex, Indices as SDataIndices, Kind as SDataKind,
-    MutationOperation as SDataMutationOperation, Owner as SDataOwner,
-    Permissions as SDataPermissions, PrivPermissions as SDataPrivPermissions, PrivSeqData,
-    PrivUserPermissions as SDataPrivUserPermissions, PubPermissions as SDataPubPermissions,
-    PubSeqData, PubUserPermissions as SDataPubUserPermissions, User as SDataUser,
-    UserPermissions as SDataUserPermissions,
+    Owner as SDataOwner, Permissions as SDataPermissions, PrivPermissions as SDataPrivPermissions,
+    PrivSeqData, PrivUserPermissions as SDataPrivUserPermissions,
+    PubPermissions as SDataPubPermissions, PubSeqData,
+    PubUserPermissions as SDataPubUserPermissions, User as SDataUser,
+    UserPermissions as SDataUserPermissions, WriteOp as SDataWriteOp,
 };
 pub use sha3::Sha3_512 as Ed25519Digest;
 pub use utils::verify_signature;

--- a/src/request/client_req.rs
+++ b/src/request/client_req.rs
@@ -40,8 +40,8 @@ impl ClientRequest {
     pub fn get_type(&self) -> Type {
         use ClientRequest::*;
         match *self {
-            ListAuthKeysAndVersion => Type::PrivateGet,
-            InsAuthKey { .. } | DelAuthKey { .. } => Type::Mutation,
+            ListAuthKeysAndVersion => Type::PrivateRead,
+            InsAuthKey { .. } | DelAuthKey { .. } => Type::Write,
         }
     }
 
@@ -51,7 +51,7 @@ impl ClientRequest {
         use ClientRequest::*;
         match *self {
             ListAuthKeysAndVersion => Response::ListAuthKeysAndVersion(Err(error)),
-            InsAuthKey { .. } | DelAuthKey { .. } => Response::Mutation(Err(error)),
+            InsAuthKey { .. } | DelAuthKey { .. } => Response::Write(Err(error)),
         }
     }
 

--- a/src/request/coins.rs
+++ b/src/request/coins.rs
@@ -42,8 +42,8 @@ impl CoinsRequest {
     pub fn get_type(&self) -> Type {
         use CoinsRequest::*;
         match *self {
-            GetBalance => Type::PrivateGet,
-            Transfer { .. } | CreateBalance { .. } => Type::Transaction,
+            GetBalance => Type::PrivateRead,
+            Transfer { .. } | CreateBalance { .. } => Type::Transfer,
         }
     }
 
@@ -63,13 +63,13 @@ impl CoinsRequest {
         match *self {
             CreateBalance { amount, .. } => {
                 if amount.as_nano() == 0 {
-                    AuthorisationKind::Mutation
+                    AuthorisationKind::Write
                 } else {
-                    AuthorisationKind::MutAndTransferCoins
+                    AuthorisationKind::WriteAndTransfer
                 }
             }
-            Transfer { .. } => AuthorisationKind::TransferCoins,
-            GetBalance => AuthorisationKind::GetBalance,
+            Transfer { .. } => AuthorisationKind::Transfer,
+            GetBalance => AuthorisationKind::ReadBalance,
         }
     }
 

--- a/src/request/idata.rs
+++ b/src/request/idata.rs
@@ -28,9 +28,9 @@ impl IDataRequest {
     pub fn get_type(&self) -> Type {
         use IDataRequest::*;
         match *self {
-            Get(IDataAddress::Pub(_)) => Type::PublicGet,
-            Get(IDataAddress::Unpub(_)) => Type::PrivateGet,
-            Put(_) | DeleteUnpub(_) => Type::Mutation,
+            Get(IDataAddress::Pub(_)) => Type::PublicRead,
+            Get(IDataAddress::Unpub(_)) => Type::PrivateRead,
+            Put(_) | DeleteUnpub(_) => Type::Write,
         }
     }
 
@@ -40,7 +40,7 @@ impl IDataRequest {
         use IDataRequest::*;
         match *self {
             Get(_) => Response::GetIData(Err(error)),
-            Put(_) | DeleteUnpub(_) => Response::Mutation(Err(error)),
+            Put(_) | DeleteUnpub(_) => Response::Write(Err(error)),
         }
     }
 
@@ -48,9 +48,9 @@ impl IDataRequest {
     pub fn authorisation_kind(&self) -> AuthorisationKind {
         use IDataRequest::*;
         match *self {
-            Get(IDataAddress::Pub(_)) => AuthorisationKind::GetPub,
-            Get(IDataAddress::Unpub(_)) => AuthorisationKind::GetPriv,
-            Put(_) | DeleteUnpub(_) => AuthorisationKind::Mutation,
+            Get(IDataAddress::Pub(_)) => AuthorisationKind::PublicRead,
+            Get(IDataAddress::Unpub(_)) => AuthorisationKind::PrivateRead,
+            Put(_) | DeleteUnpub(_) => AuthorisationKind::Write,
         }
     }
 

--- a/src/request/login_packet.rs
+++ b/src/request/login_packet.rs
@@ -43,9 +43,9 @@ impl LoginPacketRequest {
     pub fn get_type(&self) -> Type {
         use LoginPacketRequest::*;
         match *self {
-            Get(..) => Type::PrivateGet,
-            CreateFor { .. } => Type::Transaction,
-            Create { .. } | Update { .. } => Type::Mutation,
+            Get(..) => Type::PrivateRead,
+            CreateFor { .. } => Type::Transfer,
+            Create { .. } | Update { .. } => Type::Write,
         }
     }
 
@@ -56,7 +56,7 @@ impl LoginPacketRequest {
         match *self {
             Get(..) => Response::GetLoginPacket(Err(error)),
             CreateFor { .. } => Response::Transaction(Err(error)),
-            Create { .. } | Update { .. } => Response::Mutation(Err(error)),
+            Create { .. } | Update { .. } => Response::Write(Err(error)),
         }
     }
 
@@ -64,15 +64,15 @@ impl LoginPacketRequest {
     pub fn authorisation_kind(&self) -> AuthorisationKind {
         use LoginPacketRequest::*;
         match *self {
-            Create { .. } | Update { .. } => AuthorisationKind::Mutation,
+            Create { .. } | Update { .. } => AuthorisationKind::Write,
             CreateFor { amount, .. } => {
                 if amount.as_nano() == 0 {
-                    AuthorisationKind::Mutation
+                    AuthorisationKind::Write
                 } else {
-                    AuthorisationKind::MutAndTransferCoins
+                    AuthorisationKind::WriteAndTransfer
                 }
             }
-            Get(_) => AuthorisationKind::GetPriv,
+            Get(_) => AuthorisationKind::PrivateRead,
         }
     }
 

--- a/src/request/mdata.rs
+++ b/src/request/mdata.rs
@@ -94,12 +94,12 @@ impl MDataRequest {
             | ListKeys(_)
             | ListValues(_)
             | ListPermissions(_)
-            | ListUserPermissions { .. } => Type::PrivateGet,
+            | ListUserPermissions { .. } => Type::PrivateRead,
             Put(_)
             | Delete(_)
             | SetUserPermissions { .. }
             | DelUserPermissions { .. }
-            | MutateEntries { .. } => Type::Mutation,
+            | MutateEntries { .. } => Type::Write,
         }
     }
 
@@ -122,7 +122,7 @@ impl MDataRequest {
             | Delete(_)
             | SetUserPermissions { .. }
             | DelUserPermissions { .. }
-            | MutateEntries { .. } => Response::Mutation(Err(error)),
+            | MutateEntries { .. } => Response::Write(Err(error)),
         }
     }
 
@@ -134,7 +134,7 @@ impl MDataRequest {
             | Delete(_)
             | SetUserPermissions { .. }
             | DelUserPermissions { .. }
-            | MutateEntries { .. } => AuthorisationKind::Mutation,
+            | MutateEntries { .. } => AuthorisationKind::Write,
             Get(_)
             | GetValue { .. }
             | GetShell(_)
@@ -143,7 +143,7 @@ impl MDataRequest {
             | ListKeys(_)
             | ListValues(_)
             | ListPermissions(_)
-            | ListUserPermissions { .. } => AuthorisationKind::GetPriv,
+            | ListUserPermissions { .. } => AuthorisationKind::PrivateRead,
         }
     }
 

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -27,32 +27,32 @@ use std::{borrow::Cow, fmt};
 /// The type of a `Request`.
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
 pub enum Type {
-    /// Request is a Get for public data.
-    PublicGet,
-    /// Request is a Get for private data.
-    PrivateGet,
-    /// Request is a Mutation.
-    Mutation,
-    /// Request is a Transaction.
-    Transaction,
+    /// Request is a Read of public data.
+    PublicRead,
+    /// Request is a Read of private data.
+    PrivateRead,
+    /// Request is a Write.
+    Write,
+    /// Request is a Transfer.
+    Transfer,
 }
 
 /// The kind of authorisation needed for a request.
 pub enum AuthorisationKind {
-    /// Get request against public data.
-    GetPub,
-    /// Get request against private data.
-    GetPriv,
-    /// Request to get balance.
-    GetBalance,
-    /// Mutation request.
-    Mutation,
+    /// Read of public data.
+    PublicRead,
+    /// Read of private data.
+    PrivateRead,
+    /// Request to Read balance.
+    ReadBalance,
+    /// Write of data/metadata.
+    Write,
     /// Request to manage app keys.
     ManageAppKeys,
-    /// Request to transfer coins
-    TransferCoins,
-    /// Request to mutate and transfer coins
-    MutAndTransferCoins,
+    /// Request to transfer currency.
+    Transfer,
+    /// Request to write and transfer.
+    WriteAndTransfer,
 }
 
 /// RPC Request that is sent to vaults.

--- a/src/response.rs
+++ b/src/response.rs
@@ -82,10 +82,10 @@ pub enum Response {
     /// Get a list of authorised keys and the version of the auth keys container from Elders.
     ListAuthKeysAndVersion(Result<(BTreeMap<PublicKey, AppPermissions>, u64)>),
     //
-    // ===== Mutation =====
+    // ===== Write =====
     //
-    /// Return a success or failure status for a mutation operation.
-    Mutation(Result<()>),
+    /// Return a success or failure status for a write operation.
+    Write(Result<()>),
 }
 
 /// Error type for an attempted conversion from `Response` to a type implementing
@@ -137,7 +137,7 @@ try_from!(
     ListAuthKeysAndVersion
 );
 try_from!((Vec<u8>, Signature), GetLoginPacket);
-try_from!((), Mutation);
+try_from!((), Write);
 
 impl fmt::Debug for Response {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -186,8 +186,8 @@ impl fmt::Debug for Response {
             ListAuthKeysAndVersion(res) => {
                 write!(f, "Response::ListAuthKeysAndVersion({:?})", ErrorDebug(res))
             }
-            // Mutation
-            Mutation(res) => write!(f, "Response::Mutation({:?})", ErrorDebug(res)),
+            // Write
+            Write(res) => write!(f, "Response::Write({:?})", ErrorDebug(res)),
         }
     }
 }
@@ -201,8 +201,8 @@ mod tests {
 
     #[test]
     fn debug_format() {
-        let response = Response::Mutation(Ok(()));
-        assert_eq!(format!("{:?}", response), "Response::Mutation(Success)");
+        let response = Response::Write(Ok(()));
+        assert_eq!(format!("{:?}", response), "Response::Write(Success)");
         use crate::Error;
         let errored_response = Response::GetSData(Err(Error::AccessDenied));
         assert_eq!(
@@ -224,7 +224,7 @@ mod tests {
         );
         assert_eq!(
             TryFromError::WrongType,
-            unwrap_err!(IData::try_from(Mutation(Ok(()))))
+            unwrap_err!(IData::try_from(Write(Ok(()))))
         );
 
         let mut data = BTreeMap::new();
@@ -244,7 +244,7 @@ mod tests {
         );
         assert_eq!(
             TryFromError::WrongType,
-            unwrap_err!(MData::try_from(Mutation(Ok(()))))
+            unwrap_err!(MData::try_from(Write(Ok(()))))
         );
     }
 }

--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -44,11 +44,11 @@ impl Debug for PrivSeqData {
     }
 }
 
-/// Mutation operation to apply to Sequence.
-/// This is used for all kind of CRDT operationsmade on the Sequence,
+/// Write operation to apply to Sequence.
+/// This is used for all kind of CRDT operations made on the Sequence,
 /// i.e. not only on the data but also on the permissions and owner info.
 #[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Hash)]
-pub struct MutationOperation<T> {
+pub struct WriteOp<T> {
     /// Address of a Sequence object on the network.
     pub address: Address,
     /// The operation to apply.
@@ -194,13 +194,13 @@ impl Data {
     }
 
     /// Appends new entry.
-    pub fn append(&mut self, entry: Entry) -> MutationOperation<Entry> {
+    pub fn append(&mut self, entry: Entry) -> WriteOp<Entry> {
         let crdt_op = match self {
             Data::Public(data) => data.append(entry),
             Data::Private(data) => data.append(entry),
         };
 
-        MutationOperation {
+        WriteOp {
             address: *self.address(),
             crdt_op,
         }
@@ -214,11 +214,11 @@ impl Data {
         };
     }
 
-    /// Adds a new permissions entry for Public Sequence.
+    ///   a new permissions entry for Public Sequence.
     pub fn set_pub_permissions(
         &mut self,
         permissions: BTreeMap<User, PubUserPermissions>,
-    ) -> Result<MutationOperation<PubPermissions>> {
+    ) -> Result<WriteOp<PubPermissions>> {
         let address = *self.address();
         match self {
             Data::Public(data) => {
@@ -227,7 +227,7 @@ impl Data {
                     owners_index: data.owners_index(),
                     permissions,
                 });
-                Ok(MutationOperation { address, crdt_op })
+                Ok(WriteOp { address, crdt_op })
             }
             Data::Private(_) => Err(Error::InvalidOperation),
         }
@@ -237,7 +237,7 @@ impl Data {
     pub fn set_priv_permissions(
         &mut self,
         permissions: BTreeMap<PublicKey, PrivUserPermissions>,
-    ) -> Result<MutationOperation<PrivPermissions>> {
+    ) -> Result<WriteOp<PrivPermissions>> {
         let address = *self.address();
         match self {
             Data::Private(data) => {
@@ -246,7 +246,7 @@ impl Data {
                     owners_index: data.owners_index(),
                     permissions,
                 });
-                Ok(MutationOperation { address, crdt_op })
+                Ok(WriteOp { address, crdt_op })
             }
             Data::Public(_) => Err(Error::InvalidOperation),
         }
@@ -275,14 +275,14 @@ impl Data {
     }
 
     /// Adds a new owner entry.
-    pub fn set_owner(&mut self, owner: PublicKey) -> MutationOperation<Owner> {
+    pub fn set_owner(&mut self, owner: PublicKey) -> WriteOp<Owner> {
         let address = *self.address();
         let crdt_op = match self {
             Data::Public(data) => data.append_owner(owner),
             Data::Private(data) => data.append_owner(owner),
         };
 
-        MutationOperation { address, crdt_op }
+        WriteOp { address, crdt_op }
     }
 
     /// Apply Owner CRDT operation.


### PR DESCRIPTION
- Replaces Get/Mutation with Read/Write,
 as a first step of Request structure refactor.
 - MutableData not included as it is still due for CRDT refactor.