### PR TITLE
Update sequence messaging

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -32,7 +32,6 @@ jobs:
 
       - name: Release generation
         uses: softprops/action-gh-release@91409e712cf565ce9eff10c87a8d1b11b81757ae
-        if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.MERGE_BUMP_BRANCH_TOKEN }}
         with:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,6 @@ pub use sequence::{
     PrivatePermissions as SequencePrivatePermissions, PrivatePolicy as SequencePrivatePolicy,
     PrivateSeqData, PublicPermissions as SequencePublicPermissions,
     PublicPolicy as SequencePublicPolicy, PublicSeqData, User as SequenceUser,
-    WriteOp as SequenceWriteOp,
 };
 use serde::{Deserialize, Serialize};
 pub use sha3::Sha3_512 as Ed25519Digest;

--- a/src/messaging/sequence.rs
+++ b/src/messaging/sequence.rs
@@ -9,10 +9,9 @@
 
 use super::{AuthorisationKind, CmdError, DataAuthKind, QueryResponse};
 use crate::{
-    Error, PublicKey, Sequence, SequenceAddress as Address, SequenceEntry as Entry,
+    Error, Sequence, SequenceAddress as Address, SequenceDataWriteOp, SequenceEntry as Entry,
     SequenceIndex as Index, SequencePolicyWriteOp, SequencePrivatePolicy as PrivatePolicy,
-    SequencePublicPolicy as PublicPolicy, SequenceUser as User, SequenceWriteOp as WriteOp,
-    XorName,
+    SequencePublicPolicy as PublicPolicy, SequenceUser as User, XorName,
 };
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -60,18 +59,16 @@ pub enum SequenceWrite {
     /// Create a new Sequence on the network.
     New(Sequence),
     /// Edit the Sequence (insert/remove entry).
-    Edit(WriteOp<Entry>),
+    Edit(SequenceDataWriteOp<Entry>),
     /// Delete a private Sequence.
     ///
     /// This operation MUST return an error if applied to public Sequence. Only the current
     /// owner(s) can perform this action.
     Delete(Address),
-    /// Set a new owner. Only the current owner(s) can perform this action.
-    SetOwner(WriteOp<PublicKey>),
-    /// Set new permissions for public Sequence.
-    SetPublicPermissions(SequencePolicyWriteOp<PublicPolicy>),
-    /// Set new permissions for private Sequence.
-    SetPrivatePermissions(SequencePolicyWriteOp<PrivatePolicy>),
+    /// Set new policy for public Sequence.
+    SetPublicPolicy(SequencePolicyWriteOp<PublicPolicy>),
+    /// Set new policy for private Sequence.
+    SetPrivatePolicy(SequencePolicyWriteOp<PrivatePolicy>),
 }
 
 impl SequenceRead {
@@ -158,9 +155,9 @@ impl SequenceWrite {
         match self {
             New(ref data) => *data.name(),
             Delete(ref address) => *address.name(),
-            SetPublicPermissions(ref op) => *op.address.name(),
-            SetPrivatePermissions(ref op) => *op.address.name(),
-            SetOwner(ref op) => *op.address.name(),
+            SetPublicPolicy(ref op) => *op.address.name(),
+            SetPrivatePolicy(ref op) => *op.address.name(),
+            // SetOwner(ref op) => *op.address.name(),
             Edit(ref op) => *op.address.name(),
         }
     }
@@ -175,9 +172,9 @@ impl fmt::Debug for SequenceWrite {
             match *self {
                 New(_) => "NewSequence",
                 Delete(_) => "DeleteSequence",
-                SetPublicPermissions(_) => "SetPublicPermissions",
-                SetPrivatePermissions(_) => "SetPrivatePermissions",
-                SetOwner(_) => "SetOwner",
+                SetPublicPolicy(_) => "SetPublicPolicy",
+                SetPrivatePolicy(_) => "SetPrivatePolicy",
+                // SetOwner(_) => "SetOwner",
                 Edit(_) => "EditSequence",
             }
         )

--- a/src/sequence/metadata.rs
+++ b/src/sequence/metadata.rs
@@ -281,7 +281,7 @@ impl Perm for PublicPolicy {
 
     /// Gets the permissions for a user if applicable.
     fn permissions(&self, user: User) -> Option<Permissions> {
-        self.permissions.get(&user).map(|p| Permissions::Pub(*p))
+        self.permissions.get(&user).map(|p| Permissions::Public(*p))
     }
 
     /// Returns the owner.
@@ -315,7 +315,7 @@ impl Perm for PrivatePolicy {
     fn permissions(&self, user: User) -> Option<Permissions> {
         match user {
             User::Anyone => None,
-            User::Key(key) => self.permissions.get(&key).map(|p| Permissions::Priv(*p)),
+            User::Key(key) => self.permissions.get(&key).map(|p| Permissions::Private(*p)),
         }
     }
 
@@ -329,20 +329,20 @@ impl Perm for PrivatePolicy {
 #[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash, Debug)]
 pub enum Policy {
     /// Public permissions.
-    Pub(PublicPolicy),
+    Public(PublicPolicy),
     /// Private permissions.
-    Priv(PrivatePolicy),
+    Private(PrivatePolicy),
 }
 
 impl From<PrivatePolicy> for Policy {
     fn from(policy: PrivatePolicy) -> Self {
-        Policy::Priv(policy)
+        Policy::Private(policy)
     }
 }
 
 impl From<PublicPolicy> for Policy {
     fn from(policy: PublicPolicy) -> Self {
-        Policy::Pub(policy)
+        Policy::Public(policy)
     }
 }
 
@@ -350,19 +350,19 @@ impl From<PublicPolicy> for Policy {
 #[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Hash, Debug)]
 pub enum Permissions {
     /// Public permissions set.
-    Pub(PublicPermissions),
+    Public(PublicPermissions),
     /// Private permissions set.
-    Priv(PrivatePermissions),
+    Private(PrivatePermissions),
 }
 
 impl From<PrivatePermissions> for Permissions {
     fn from(permission_set: PrivatePermissions) -> Self {
-        Permissions::Priv(permission_set)
+        Permissions::Private(permission_set)
     }
 }
 
 impl From<PublicPermissions> for Permissions {
     fn from(permission_set: PublicPermissions) -> Self {
-        Permissions::Pub(permission_set)
+        Permissions::Public(permission_set)
     }
 }


### PR DESCRIPTION
- Remove general WriteOp, replace with specific policy write ops or data write op
- clean up some pub/priv abbreviations leftover
- remove CD check for releases, can just go off of commit msg