### PR TITLE
refactor(transfers): rename account id to wallet id

### DIFF
--- a/src/messaging/network.rs
+++ b/src/messaging/network.rs
@@ -8,8 +8,8 @@
 // Software.
 
 use crate::{
-    AccountId, Address, Blob, BlobAddress, DebitAgreementProof, Error, PublicKey, ReplicaEvent,
-    Result, Signature, SignedTransfer, TransferId, TransferValidated, XorName,
+    Address, Blob, BlobAddress, DebitAgreementProof, Error, PublicKey, ReplicaEvent, Result,
+    Signature, SignedTransfer, TransferId, TransferValidated, XorName,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
@@ -104,7 +104,7 @@ pub enum NodeQuery {
 pub enum NodeRewardQuery {
     /// Sent by the new section to the
     /// old section after node relocation.
-    GetAccountId {
+    GetWalletId {
         /// The id of the node
         /// in the old section.
         old_node_id: XorName,
@@ -158,10 +158,10 @@ pub enum NodeQueryResponse {
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Hash, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub enum NodeRewardQueryResponse {
-    /// Returns the account id
+    /// Returns the wallet address
     /// together with the new node id,
     /// that followed with the original query.
-    GetAccountId(Result<(PublicKey, XorName)>),
+    GetWalletId(Result<(PublicKey, XorName)>),
 }
 
 ///
@@ -221,7 +221,7 @@ pub enum NodeRewardError {
     ///
     RewardClaiming {
         ///
-        account_id: AccountId,
+        wallet: PublicKey,
         ///
         error: Error,
     },
@@ -230,7 +230,7 @@ pub enum NodeRewardError {
         ///
         id: TransferId,
         ///
-        account: AccountId,
+        wallet: PublicKey,
         ///
         error: Error,
     },
@@ -239,7 +239,7 @@ pub enum NodeRewardError {
         ///
         id: TransferId,
         ///
-        account: AccountId,
+        wallet: PublicKey,
         ///
         error: Error,
     },
@@ -291,7 +291,7 @@ impl NodeQuery {
             Transfers(transfer_query) => match transfer_query {
                 GetReplicaEvents(section_key) => Section((*section_key).into()),
             },
-            Rewards(GetAccountId { old_node_id, .. }) => Section(*old_node_id),
+            Rewards(GetWalletId { old_node_id, .. }) => Section(*old_node_id),
         }
     }
 }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -5,11 +5,8 @@ use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use threshold_crypto::PublicKeySet;
 
-/// Actor id
-pub type AccountId = PublicKey;
-
 /// Transfer ID.
-pub type TransferId = Dot<AccountId>;
+pub type TransferId = Dot<PublicKey>;
 
 /// A transfer of money between two keys.
 #[derive(Clone, Hash, Eq, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
@@ -17,7 +14,7 @@ pub struct Transfer {
     /// Transfer ID, containing source key.
     pub id: TransferId,
     /// The destination to transfer to.
-    pub to: AccountId,
+    pub to: PublicKey,
     /// The amount to transfer.
     pub amount: Money,
 }
@@ -34,7 +31,7 @@ impl Transfer {
     }
 
     /// Get the sender of this transfer
-    pub fn from(&self) -> AccountId {
+    pub fn from(&self) -> PublicKey {
         self.id.actor
     }
 


### PR DESCRIPTION
We've already started calling it wallet, and using a PublicKey for it, so this just makes it consistent.

PRs to sn_transfers and safe-vault also needed.