### PR TITLE
chore(ci): update tarpaulin action version and extend timeout

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -78,9 +78,9 @@ jobs:
 
       # Run cargo tarpaulin & push result to coveralls.io
       - name: rust-tarpaulin code coverage check
-        uses: actions-rs/tarpaulin@v0.1.2
+        uses: actions-rs/tarpaulin@v0.1
         with:
-          args: '-v --release --out Lcov'
+          args: '-v -t 300 --release --out Lcov'
       - name: Push code coverage results to coveralls.io
         uses: coverallsapp/github-action@master
         with:


### PR DESCRIPTION
Official tarpaulin action latest released version is v0.1 so switched to that.

Some proptests were timing out so tested a couple of timeout configurations and have settled on 300 seconds.