### PR TITLE
Omit address when serializing private data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ crdts = "4.3.0"
 sha3 = "~0.8.2"
 threshold_crypto = "~0.4.0"
 tiny-keccak = "~1.5.0"
-xor_name = "1.1.0"
+xor_name = { git = "https://github.com/maidsafe/xor_name", rev="72f1c1a02101db4612cc8e8d9aa64e490034b938" }
 ed25519 = "1.0.1"
 signature = "1.1.0"
 rand_core = "~0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ crdts = "4.3.0"
 sha3 = "~0.8.2"
 threshold_crypto = "~0.4.0"
 tiny-keccak = "~1.5.0"
-xor_name = { git = "https://github.com/maidsafe/xor_name", rev="72f1c1a02101db4612cc8e8d9aa64e490034b938" }
+xor_name = "1.1.9"
 ed25519 = "1.0.1"
 signature = "1.1.0"
 rand_core = "~0.5.1"

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -82,19 +82,15 @@ impl PrivateData {
 
 impl Serialize for PrivateData {
     fn serialize<S: Serializer>(&self, serialiser: S) -> Result<S::Ok, S::Error> {
-        (&self.address, &self.value, &self.owner).serialize(serialiser)
+        // Address is omitted since it's derived from value + owner
+        (&self.value, &self.owner).serialize(serialiser)
     }
 }
 
 impl<'de> Deserialize<'de> for PrivateData {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let (address, value, owner): (Address, Vec<u8>, PublicKey) =
-            Deserialize::deserialize(deserializer)?;
-        Ok(Self {
-            address,
-            value,
-            owner,
-        })
+        let (value, owner) = Deserialize::deserialize(deserializer)?;
+        Ok(Self::new(value, owner))
     }
 }
 

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -71,19 +71,23 @@ impl PrivateData {
 
     /// Returns size of this data after serialisation.
     pub fn serialised_size(&self) -> u64 {
-        serialized_size(self).unwrap_or(u64::MAX)
+        serialized_size(&self.serialised_structure()).unwrap_or(u64::MAX)
     }
 
     /// Returns `true` if the size is valid.
     pub fn validate_size(&self) -> bool {
         self.serialised_size() <= MAX_BLOB_SIZE_IN_BYTES
     }
+
+    fn serialised_structure(&self) -> (&[u8], &PublicKey) {
+        (&self.value, &self.owner)
+    }
 }
 
 impl Serialize for PrivateData {
     fn serialize<S: Serializer>(&self, serialiser: S) -> Result<S::Ok, S::Error> {
         // Address is omitted since it's derived from value + owner
-        (&self.value, &self.owner).serialize(serialiser)
+        self.serialised_structure().serialize(serialiser)
     }
 }
 
@@ -405,7 +409,7 @@ mod tests {
 
     #[test]
     fn zbase32_encode_decode_idata_address() -> Result<()> {
-        let name = XorName(rand::random());
+        let name = XorName::random();
         let address = Address::Public(name);
         let encoded = address.encode_to_zbase32()?;
         let decoded = self::Address::decode_from_zbase32(&encoded)?;

--- a/src/keys/public_key.rs
+++ b/src/keys/public_key.rs
@@ -39,6 +39,15 @@ pub enum PublicKey {
 }
 
 impl PublicKey {
+    /// Returns the bytes of the underlying public key
+    pub fn to_bytes(&self) -> Vec<u8> {
+        match self {
+            PublicKey::Ed25519(pub_key) => pub_key.to_bytes().into(),
+            PublicKey::Bls(pub_key) => pub_key.to_bytes().into(),
+            PublicKey::BlsShare(pub_key) => pub_key.to_bytes().into(),
+        }
+    }
+
     /// Returns the ed25519 key, if applicable.
     pub fn ed25519(&self) -> Option<ed25519_dalek::PublicKey> {
         if let Self::Ed25519(key) = self {


### PR DESCRIPTION
Depends on https://github.com/maidsafe/xor_name/pull/59

`PrivateKey::new()` now no longer returns result since we don't depend on bincode to derive the address.