### PR TITLE
refactor(chunk): rename blob to chunk

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -45,27 +45,21 @@ pub enum Error {
     /// Serialization error
     #[error("Serialisation error: {0}")]
     Serialisation(String),
-
     /// Entry already exists. Contains the current entry Key.
     #[error("Entry already exists {0}")]
     EntryExists(u8),
-
     /// Supplied actions are not valid
     #[error("Some entry actions are not valid")]
     InvalidEntryActions(BTreeMap<Vec<u8>, Error>),
-
     /// Entry could not be found on the data
     #[error("Requested entry not found")]
     NoSuchEntry,
-
     /// Key does not exist
     #[error("Key does not exist")]
     NoSuchKey,
-
     /// Owner is not valid
     #[error("Owner is not a PublicKeySet")]
     InvalidOwnerNotPublicKeySet,
-
     /// No Policy has been set to the data
     #[error("No policy has been set for this data")]
     PolicyNotSet,
@@ -73,11 +67,9 @@ pub enum Error {
     /// current data version.
     #[error("Invalid version provided: {0}")]
     InvalidSuccessor(u64),
-
     /// Invalid mutating operation as it causality dependency is currently not satisfied
     #[error("Operation is not causally ready. Ensure you have the full history of operations.")]
     OpNotCausallyReady,
-
     /// Invalid Operation such as a POST on ImmutableData
     #[error("Invalid operation")]
     InvalidOperation,
@@ -100,7 +92,6 @@ pub enum Error {
     // TODO: this should not be possible
     #[error("No such recipient key balance")]
     NoSuchRecipient,
-
     /// Expected data size exceeded.
     #[error("Size of the structure exceeds the limit")]
     ExceededSize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
     unused_results
 )]
 
-mod blob;
+mod chunk;
 mod errors;
 mod keys;
 mod map;
@@ -41,9 +41,9 @@ mod token;
 mod transfer;
 mod utils;
 
-pub use blob::{
-    Address as BlobAddress, Data as Blob, Kind as BlobKind, PrivateData as PrivateBlob,
-    PublicData as PublicBlob, MAX_BLOB_SIZE_IN_BYTES,
+pub use chunk::{
+    Address as ChunkAddress, Chunk, Kind as ChunkKind, PrivateChunk, PublicChunk,
+    MAX_CHUNK_SIZE_IN_BYTES,
 };
 pub use errors::{Error, Result};
 pub use keys::{
@@ -58,6 +58,7 @@ pub use map::{
     UnseqEntries as MapUnseqEntries, UnseqEntryAction as MapUnseqEntryAction,
     UnseqEntryActions as MapUnseqEntryActions, Value as MapValue, Values as MapValues,
 };
+pub use register::Address as RegisterAddress;
 pub use rewards::{AccumulatingReward, NodeAge, RewardAccumulation, RewardProposal};
 pub use section::SectionElders;
 pub use sequence::{
@@ -71,7 +72,7 @@ pub use sequence::{
 pub use token::Token;
 pub use transfer::*;
 
-use register::{Address as RegisterAddress, Register};
+use register::Register;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use xor_name::XorName;
@@ -80,10 +81,10 @@ use xor_name::XorName;
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Debug)]
 pub enum Data {
-    /// Blob.
-    Immutable(Blob),
-    /// MutableData.
-    Mutable(Map),
+    /// Chunk.
+    Chunk(Chunk),
+    /// Map.
+    Map(Map),
     /// Sequence.
     Sequence(Sequence),
     /// Register.
@@ -93,8 +94,8 @@ pub enum Data {
 /// Object storing an address of data on the network
 #[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize, Debug, PartialOrd, Ord)]
 pub enum DataAddress {
-    /// Blob Address
-    Blob(BlobAddress),
+    /// Chunk Address
+    Chunk(ChunkAddress),
     /// Map Address
     Map(MapAddress),
     /// Sequence Address
@@ -107,8 +108,8 @@ impl Data {
     /// Returns true if public.
     pub fn is_public(&self) -> bool {
         match *self {
-            Self::Immutable(ref idata) => idata.is_public(),
-            Self::Mutable(_) => false,
+            Self::Chunk(ref chunk) => chunk.is_public(),
+            Self::Map(_) => false,
             Self::Sequence(ref sequence) => sequence.is_public(),
             Self::Register(ref register) => register.is_public(),
         }
@@ -120,15 +121,15 @@ impl Data {
     }
 }
 
-impl From<Blob> for Data {
-    fn from(data: Blob) -> Self {
-        Self::Immutable(data)
+impl From<Chunk> for Data {
+    fn from(chunk: Chunk) -> Self {
+        Self::Chunk(chunk)
     }
 }
 
 impl From<Map> for Data {
     fn from(data: Map) -> Self {
-        Self::Mutable(data)
+        Self::Map(data)
     }
 }
 

--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -48,6 +48,7 @@ pub struct Data {
     data: SeqData,
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl Data {
     /// Constructs a new Public Sequence Data.
     /// The 'authority' is assumed to be the PK which the messages were and will be


### PR DESCRIPTION
- The `Blob` is meant for a design where it forms a set of one or more chunks.
- Since the design is not yet in place, this confusing discrepancy is removed, and thus single chunks are now called chunks instead of blobs.
BREAKING CHANGE: Blob is renamed to Chunk.